### PR TITLE
Add missing content_type kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- `content_type` keyword argument in `cloud_storage_upload_blob_from_file` task - [#47](https://github.com/PrefectHQ/prefect-gcp/pull/47)
 
 ### Changed
 

--- a/prefect_gcp/cloud_storage.py
+++ b/prefect_gcp/cloud_storage.py
@@ -229,7 +229,7 @@ async def cloud_storage_upload_blob_from_string(
         blob: Name of the Cloud Storage blob.
         gcp_credentials: Credentials to use for authentication with GCP.
         content_type: Type of content being uploaded.
-        chunk_size (int, optional): The size of a chunk of data whenever
+        chunk_size: The size of a chunk of data whenever
             iterating (in bytes). This must be a multiple of 256 KB
             per the API specification.
         encryption_key: An encryption key.
@@ -281,6 +281,7 @@ async def cloud_storage_upload_blob_from_file(
     bucket: str,
     blob: str,
     gcp_credentials: "GcpCredentials",
+    content_type: Optional[str] = None,
     chunk_size: Optional[int] = None,
     encryption_key: Optional[str] = None,
     timeout: Union[float, Tuple[float, float]] = 60,
@@ -296,7 +297,8 @@ async def cloud_storage_upload_blob_from_file(
         bucket: Name of the bucket.
         blob: Name of the Cloud Storage blob.
         gcp_credentials: Credentials to use for authentication with GCP.
-        chunk_size (int, optional): The size of a chunk of data whenever
+        content_type: Type of content being uploaded.
+        chunk_size: The size of a chunk of data whenever
             iterating (in bytes). This must be a multiple of 256 KB
             per the API specification.
         encryption_key: An encryption key.
@@ -336,9 +338,16 @@ async def cloud_storage_upload_blob_from_file(
     )
 
     if isinstance(file, BytesIO):
-        partial_upload = partial(blob_obj.upload_from_file, file, timeout=timeout)
+        partial_upload = partial(
+            blob_obj.upload_from_file, file, content_type=content_type, timeout=timeout
+        )
     else:
-        partial_upload = partial(blob_obj.upload_from_filename, file, timeout=timeout)
+        partial_upload = partial(
+            blob_obj.upload_from_filename,
+            file,
+            content_type=content_type,
+            timeout=timeout,
+        )
     await to_thread.run_sync(partial_upload)
     return blob
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,13 @@ from unittest.mock import MagicMock
 
 import pytest
 from google.cloud.exceptions import NotFound
+from prefect.testing.utilities import prefect_test_harness
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prefect_db():
+    with prefect_test_harness():
+        yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,8 @@ class CloudStorageClient:
         self.credentials = credentials
         self.project = project
 
-    def create_bucket(self, bucket, location=None):
-        return {"bucket": bucket, "location": location}
+    def create_bucket(self, bucket, location=None, **create_kwargs):
+        return {"bucket": bucket, "location": location, **create_kwargs}
 
     def get_bucket(self, bucket):
         blob_obj = MagicMock()

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -47,17 +47,18 @@ def test_cloud_storage_download_blob_as_bytes(gcp_credentials):
 @pytest.mark.parametrize(
     "file",
     [
-        "./file_path",
-        BytesIO(b"bytes_data"),
+        "./file_path.html",
+        BytesIO(b"<div>bytes_data</div>"),
     ],
 )
 def test_cloud_storage_upload_blob_from_file(file, gcp_credentials):
     blob = "blob"
+    content_type = "text/html"
 
     @flow
     def test_flow():
         return cloud_storage_upload_blob_from_file(
-            file, "bucket", blob, gcp_credentials
+            file, "bucket", blob, gcp_credentials, content_type=content_type
         )
 
     assert test_flow() == blob

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -20,7 +20,9 @@ def test_cloud_storage_create_bucket(gcp_credentials):
 
     @flow
     def test_flow():
-        return cloud_storage_create_bucket(bucket, gcp_credentials, location=location)
+        return cloud_storage_create_bucket(
+            bucket, gcp_credentials, location=location, timeout=10
+        )
 
     assert test_flow() == "expected"
 
@@ -30,7 +32,7 @@ def test_cloud_storage_download_blob_to_file(path, gcp_credentials):
     @flow
     def test_flow():
         return cloud_storage_download_blob_to_file(
-            "bucket", "blob", path, gcp_credentials
+            "bucket", "blob", path, gcp_credentials, timeout=10
         )
 
     assert test_flow() == path
@@ -39,7 +41,9 @@ def test_cloud_storage_download_blob_to_file(path, gcp_credentials):
 def test_cloud_storage_download_blob_as_bytes(gcp_credentials):
     @flow
     def test_flow():
-        return cloud_storage_download_blob_as_bytes("bucket", "blob", gcp_credentials)
+        return cloud_storage_download_blob_as_bytes(
+            "bucket", "blob", gcp_credentials, timeout=10
+        )
 
     assert test_flow() == b"bytes"
 
@@ -58,7 +62,7 @@ def test_cloud_storage_upload_blob_from_file(file, gcp_credentials):
     @flow
     def test_flow():
         return cloud_storage_upload_blob_from_file(
-            file, "bucket", blob, gcp_credentials, content_type=content_type
+            file, "bucket", blob, gcp_credentials, content_type=content_type, timeout=10
         )
 
     assert test_flow() == blob
@@ -78,7 +82,7 @@ def test_cloud_storage_upload_blob_from_string(data, blob, gcp_credentials):
     @flow
     def test_flow():
         return cloud_storage_upload_blob_from_string(
-            data, "bucket", "blob", gcp_credentials
+            data, "bucket", "blob", gcp_credentials, timeout=10
         )
 
     assert test_flow() == blob
@@ -94,6 +98,7 @@ def test_cloud_storage_copy_blob(dest_blob, gcp_credentials):
             "source_blob",
             gcp_credentials,
             dest_blob=dest_blob,
+            timeout=10,
         )
 
     if dest_blob is None:


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-gcp! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Adds `content_type` to `cloud_storage_upload_blob_from_file`.

It's placed in the middle of the existing kwargs to match `cloud_storage_upload_blob_from_string` ordering.

Not sure if I should additionally add `**upload_kwargs` for other keywords missing?

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes https://github.com/PrefectHQ/prefect-gcp/issues/46

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
