### PR TITLE
Add external_config parameter to bigquery_create_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- `external_config` keyword argument in `bigquery_create_table` task - [#53](https://github.com/PrefectHQ/prefect-gcp/pull/53)
 - `content_type` keyword argument in `cloud_storage_upload_blob_from_file` task - [#47](https://github.com/PrefectHQ/prefect-gcp/pull/47)
 - `**kwargs` for all tasks in the module `cloud_storage.py` - [#47](https://github.com/PrefectHQ/prefect-gcp/pull/47)
 

--- a/prefect_gcp/bigquery.py
+++ b/prefect_gcp/bigquery.py
@@ -164,7 +164,7 @@ async def bigquery_create_table(
     time_partitioning: TimePartitioning = None,
     project: Optional[str] = None,
     location: str = "US",
-    external_config: Optional[ExternalConfig] = None
+    external_config: Optional[ExternalConfig] = None,
 ) -> str:
     """
     Creates table in BigQuery.
@@ -209,7 +209,7 @@ async def bigquery_create_table(
     logger = get_run_logger()
     logger.info("Creating %s.%s", dataset, table)
 
-    if not external_config and not schema: 
+    if not external_config and not schema:
         raise ValueError("Either a schema or an external config must be provided.")
 
     client = gcp_credentials.get_bigquery_client(project=project, location=location)

--- a/prefect_gcp/bigquery.py
+++ b/prefect_gcp/bigquery.py
@@ -179,7 +179,7 @@ async def bigquery_create_table(
         project: Project to initialize the BigQuery Client with; if
             not provided, will default to the one inferred from your credentials.
         location: The location of the dataset that will be written to.
-        external_config: The [external data source](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_external_data_configuration).
+        external_config: The [external data source](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_external_data_configuration).  # noqa
     Returns:
         Table name.
     Example:

--- a/prefect_gcp/bigquery.py
+++ b/prefect_gcp/bigquery.py
@@ -179,7 +179,7 @@ async def bigquery_create_table(
         project: Project to initialize the BigQuery Client with; if
             not provided, will default to the one inferred from your credentials.
         location: The location of the dataset that will be written to.
-        external_config: The [external data source](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_external_data_configuration)
+        external_config: The [external data source](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_external_data_configuration).
     Returns:
         Table name.
     Example:

--- a/prefect_gcp/bigquery.py
+++ b/prefect_gcp/bigquery.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 
 from anyio import to_thread
 from google.cloud.bigquery import (
+    ExternalConfig,
     LoadJob,
     LoadJobConfig,
     QueryJobConfig,
@@ -157,16 +158,16 @@ async def bigquery_query(
 async def bigquery_create_table(
     dataset: str,
     table: str,
-    schema: List[SchemaField],
     gcp_credentials: "GcpCredentials",
+    schema: Optional[List[SchemaField]] = None,
     clustering_fields: List[str] = None,
     time_partitioning: TimePartitioning = None,
     project: Optional[str] = None,
     location: str = "US",
+    external_config: Optional[ExternalConfig] = None
 ) -> str:
     """
     Creates table in BigQuery.
-
     Args:
         dataset: Name of a dataset in that the table will be created.
         table: Name of a table to create.
@@ -177,18 +178,16 @@ async def bigquery_create_table(
             of the newly created table
         project: Project to initialize the BigQuery Client with; if
             not provided, will default to the one inferred from your credentials.
-        location: location of the dataset that will be written to.
-
+        location: The location of the dataset that will be written to.
+        external_config: The [external data source](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_external_data_configuration)
     Returns:
         Table name.
-
     Example:
         ```python
         from prefect import flow
         from prefect_gcp import GcpCredentials
         from prefect_gcp.bigquery import bigquery_create_table
         from google.cloud.bigquery import SchemaField
-
         @flow
         def example_bigquery_create_table_flow():
             gcp_credentials = GcpCredentials(project="project")
@@ -204,12 +203,14 @@ async def bigquery_create_table(
                 gcp_credentials=gcp_credentials
             )
             return result
-
         example_bigquery_create_table_flow()
         ```
     """
     logger = get_run_logger()
     logger.info("Creating %s.%s", dataset, table)
+
+    if not external_config and not schema: 
+        raise ValueError("Either a schema or an external config must be provided.")
 
     client = gcp_credentials.get_bigquery_client(project=project, location=location)
     try:
@@ -228,6 +229,10 @@ async def bigquery_create_table(
     except NotFound:
         logger.debug("Table %s not found, creating", table)
         table_obj = Table(table_ref, schema=schema)
+
+        # external data configuration
+        if external_config:
+            table_obj.external_data_configuration = external_config
 
         # cluster for optimal data sorting/access
         if clustering_fields:

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -76,7 +76,7 @@ def test_bigquery_create_table_external(gcp_credentials, external_config):
         return table
 
     if external_config is None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Either a schema or an external"):
             test_flow()
     else:
         assert test_flow() == "table"
@@ -122,7 +122,7 @@ def test_bigquery_load_cloud_storage(gcp_credentials):
 
 
 def test_bigquery_load_file(gcp_credentials):
-    
+
     path = os.path.abspath(__file__)
 
     @flow
@@ -141,3 +141,4 @@ def test_bigquery_load_file(gcp_credentials):
     assert result.output == "file"
     assert result._client is None
     assert result._completion_lock is None
+    

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -62,7 +62,9 @@ def test_bigquery_create_table(gcp_credentials):
     assert test_flow() == "table"
 
 
-@pytest.mark.parametrize("external_config", [None, ExternalConfig(source_format="PARQUET")])
+@pytest.mark.parametrize(
+    "external_config", [None, ExternalConfig(source_format="PARQUET")]
+)
 def test_bigquery_create_table_external(gcp_credentials, external_config):
     @flow
     def test_flow():
@@ -141,4 +143,3 @@ def test_bigquery_load_file(gcp_credentials):
     assert result.output == "file"
     assert result._client is None
     assert result._completion_lock is None
-    

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -122,6 +122,9 @@ def test_bigquery_load_cloud_storage(gcp_credentials):
 
 
 def test_bigquery_load_file(gcp_credentials):
+    
+    path = os.path.abspath(__file__)
+
     @flow
     def test_flow():
         schema = [

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from google.cloud.bigquery import SchemaField, ExternalConfig
+from google.cloud.bigquery import ExternalConfig, SchemaField
 from prefect import flow
 
 from prefect_gcp.bigquery import (
@@ -53,8 +53,8 @@ def test_bigquery_create_table(gcp_credentials):
         table = bigquery_create_table(
             "dataset",
             "table",
-            schema,
             gcp_credentials,
+            schema,
             clustering_fields=["text"],
         )
         return table


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-gcp! 🎉-->

## Summary
Adds `external_config` keyword argument to `bigquery_create_table` task so users can provide a `google.cloud.bigquery.ExternalConfig` for creating a BigQuery [External Table](https://cloud.google.com/bigquery/docs/external-tables).

## Relevant Issue(s)
Closes #52 

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
