### PR TITLE
Fixes inferring project from service account and get credentials from google.auth.default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Retrieving the `project_id` from service account if `project` is not specified - [#57](https://github.com/PrefectHQ/prefect-gcp/pull/57)
+- Retrieving the `project_id` from service account or `quota_project_id` from gcloud CLI if `project` is not specified - [#57](https://github.com/PrefectHQ/prefect-gcp/pull/57)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Invoke `google.auth.default` if both `service_account_info` and `service_account_file` is not specified - [#57](https://github.com/PrefectHQ/prefect-gcp/pull/57)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `infer_project` keyword in `GcpCredentials` - []()
+- `infer_project` keyword in `GcpCredentials` - [#57](https://github.com/PrefectHQ/prefect-gcp/pull/57)
 
 ### Changed
 
-- `project` is no longer automatically inferred from credentials without `infer_project` - []()
+- `project` is no longer automatically inferred from credentials without `infer_project` - [#57](https://github.com/PrefectHQ/prefect-gcp/pull/57)
 
 ### Deprecated
 
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Retrieving the `project_id` from service account if `project` is not specified - []()
+- Retrieving the `project_id` from service account if `project` is not specified - [#57](https://github.com/PrefectHQ/prefect-gcp/pull/57)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `infer_project` keyword in `GcpCredentials` - [#57](https://github.com/PrefectHQ/prefect-gcp/pull/57)
-
 ### Changed
-
-- `project` is no longer automatically inferred from credentials without `infer_project` - [#57](https://github.com/PrefectHQ/prefect-gcp/pull/57)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `infer_project` keyword in `GcpCredentials` - []()
+
 ### Changed
+
+- `project` is no longer automatically inferred from credentials without `infer_project` - []()
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Retrieving the `project_id` from service account if `project` is not specified - []()
 
 ### Security
 

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -118,9 +118,13 @@ class GcpCredentials(Block):
     def block_initialization(self):
         credentials = self.get_credentials_from_service_account()
         if self.project is None:
-            self.project = credentials.project_id
+            if self.service_account_info or self.service_account_file:
+                credentials_project = credentials.project_id
+            else:  # google.auth.default using gcloud auth application-default login
+                credentials_project = credentials.quota_project_id
+            self.project = credentials_project
 
-    def get_credentials_from_service_account(self) -> Union[Credentials, None]:
+    def get_credentials_from_service_account(self) -> Credentials:
         """
         Helper method to serialize credentials by using either
         service_account_file or service_account_info.

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -87,7 +87,6 @@ class GcpCredentials(Block):
     service_account_file: Optional[Path] = None
     service_account_info: Optional[Union[Dict[str, str], Json]] = None
     project: Optional[str] = None
-    infer_project: bool = False
 
     @root_validator
     def _provide_one_service_account_source(cls, values):
@@ -105,12 +104,6 @@ class GcpCredentials(Block):
             )
         return values
 
-    @root_validator
-    def _cannot_infer_project_with_specified_project(cls, values):
-        if values.get("infer_project") and values.get("project"):
-            raise ValueError("Unable to infer project with a project already set")
-        return values
-
     @validator("service_account_file")
     def _check_service_account_file(cls, file):
         """Get full path of provided file and make sure that it exists."""
@@ -123,9 +116,8 @@ class GcpCredentials(Block):
         return service_account_file
 
     def block_initialization(self):
-        if self.infer_project:
-            credentials = self.get_credentials_from_service_account()
-            self.project = credentials.project_id
+        credentials = self.get_credentials_from_service_account()
+        self.project = credentials.project_id
 
     def get_credentials_from_service_account(self) -> Union[Credentials, None]:
         """

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -117,7 +117,8 @@ class GcpCredentials(Block):
 
     def block_initialization(self):
         credentials = self.get_credentials_from_service_account()
-        self.project = credentials.project_id
+        if self.project is None:
+            self.project = credentials.project_id
 
     def get_credentials_from_service_account(self) -> Union[Credentials, None]:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -159,3 +160,29 @@ def gcp_credentials():
         lambda *args, **kwargs: SecretManagerClient()
     )
     return gcp_credentials_mock
+
+
+@pytest.fixture()
+def service_account_info_dict(monkeypatch):
+    monkeypatch.setattr(
+        "google.auth.crypt._cryptography_rsa.serialization.load_pem_private_key",
+        lambda *args, **kwargs: args[0],
+    )
+    _service_account_info = {
+        "project_id": "my_project",
+        "token_uri": "my-token-uri",
+        "client_email": "my-client-email",
+        "private_key": "my-private-key",
+    }
+    return _service_account_info
+
+
+@pytest.fixture()
+def service_account_info_json(service_account_info_dict):
+    _service_account_info = json.dumps(service_account_info_dict)
+    return _service_account_info
+
+
+@pytest.fixture(params=["service_account_info_dict", "service_account_info_json"])
+def service_account_info(request):
+    return request.getfixturevalue(request.param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,20 @@ def prefect_db():
 
 
 @pytest.fixture
+def google_auth(monkeypatch):
+    google_auth_mock = MagicMock()
+    default_credentials_mock = MagicMock(
+        client_id="my_client_id", quota_project_id="my_project"
+    )
+    google_auth_mock.default.side_effect = lambda *args, **kwargs: (
+        default_credentials_mock,
+        None,
+    )
+    monkeypatch.setattr("google.auth", google_auth_mock)
+    return google_auth_mock
+
+
+@pytest.fixture
 def oauth2_credentials(monkeypatch):
     CredentialsMock = MagicMock()
     CredentialsMock.from_service_account_info.side_effect = (
@@ -150,12 +164,8 @@ class SecretManagerClient:
 
 
 @pytest.fixture
-def gcp_credentials(monkeypatch):
-    google_auth_mock = MagicMock()
-    google_auth_mock.default.side_effect = lambda: (MagicMock(), MagicMock())
-    monkeypatch.setattr("google.auth", google_auth_mock)
+def gcp_credentials(monkeypatch, google_auth):
     gcp_credentials_mock = GcpCredentials(project="gcp_credentials_project")
-    google_auth_mock.default.assert_called_with()
     gcp_credentials_mock.get_cloud_storage_client = (
         lambda *args, **kwargs: CloudStorageClient()
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,8 +150,12 @@ class SecretManagerClient:
 
 
 @pytest.fixture
-def gcp_credentials():
+def gcp_credentials(monkeypatch):
+    google_auth_mock = MagicMock()
+    google_auth_mock.default.side_effect = lambda: (MagicMock(), MagicMock())
+    monkeypatch.setattr("google.auth", google_auth_mock)
     gcp_credentials_mock = GcpCredentials(project="gcp_credentials_project")
+    google_auth_mock.default.assert_called_with()
     gcp_credentials_mock.get_cloud_storage_client = (
         lambda *args, **kwargs: CloudStorageClient()
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,9 @@ def prefect_db():
 @pytest.fixture
 def oauth2_credentials(monkeypatch):
     CredentialsMock = MagicMock()
-    CredentialsMock.from_service_account_info.side_effect = lambda json, scopes: json
+    CredentialsMock.from_service_account_info.side_effect = (
+        lambda json, scopes: MagicMock(scopes=scopes, **json)
+    )
     CredentialsMock.from_service_account_file.side_effect = lambda file, scopes: file
     monkeypatch.setattr("prefect_gcp.credentials.Credentials", CredentialsMock)
 

--- a/tests/test_cloud_run.py
+++ b/tests/test_cloud_run.py
@@ -396,13 +396,11 @@ class TestExecution:
 
 
 @pytest.fixture
-def cloud_run_job():
+def cloud_run_job(service_account_info):
     return CloudRunJob(
         image="gcr.io//not-a/real-image",
         region="middle-earth2",
-        credentials=GcpCredentials(
-            service_account_info={"hello": "world"}, project="my-project"
-        ),
+        credentials=GcpCredentials(service_account_info=service_account_info),
     )
 
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -87,26 +87,9 @@ def test_get_credentials_from_service_account_both_error(
         ).get_credentials_from_service_account()
 
 
-def test_cannot_infer_project_with_specified_project(
-    service_account_info_dict, oauth2_credentials
-):
-    with pytest.raises(ValueError):
-        GcpCredentials(
-            service_account_info=service_account_info_dict,
-            project="some_project",
-            infer_project=True,
-        )
-
-
-@pytest.mark.parametrize("infer_project", [True, False])
-def test_block_initialization(infer_project, service_account_info, oauth2_credentials):
-    gcp_credentials = GcpCredentials(
-        service_account_info=service_account_info, infer_project=infer_project
-    )
-    if infer_project:
-        assert gcp_credentials.project == "my_project"
-    else:
-        assert gcp_credentials.project is None
+def test_block_initialization(service_account_info, oauth2_credentials):
+    gcp_credentials = GcpCredentials(service_account_info=service_account_info)
+    assert gcp_credentials.project == "my_project"
 
 
 @pytest.mark.parametrize("override_project", [None, "override_project"])
@@ -149,7 +132,6 @@ class MockTargetConfigs(Block):
         configs = self.credentials.dict()
         for key in Block().dict():
             configs.pop(key, None)
-            configs.pop("infer_project")
         return configs
 
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -86,6 +86,11 @@ def test_block_initialization_project_specified(
     assert gcp_credentials.project == "overrided_project"
 
 
+def test_block_initialization_gcloud_cli(google_auth, oauth2_credentials):
+    gcp_credentials = GcpCredentials()
+    assert gcp_credentials.project == "my_project"
+
+
 @pytest.mark.parametrize("override_project", [None, "override_project"])
 def test_get_cloud_storage_client(
     override_project, service_account_info, oauth2_credentials, storage_client


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-gcp! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

- Previously, tried to get the `project` attribute from service account, but `project_id` is the proper attribute.
- (https://github.com/PrefectHQ/prefect-dbt/blob/main/prefect_dbt/cli/configs/base.py#L55)
- explicitly call `google.auth.default` to get a credentials object if no `service_account* `is specified

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
I think calling google.auth.default will resolve https://github.com/PrefectHQ/prefect-dbt/issues/56 so the profile.yml can be populated from a credentials object

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
