### PR TITLE
Make get_access_token sync compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `VertexAICustomTrainingJob` infrastructure block - [#75](https://github.com/PrefectHQ/prefect-gcp/pull/75)
-
 ### Changed
+
+- Made `GcpCredentials.get_access_token` sync compatible - [#80](https://github.com/PrefectHQ/prefect-gcp/pull/80)
 
 ### Deprecated
 

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -30,7 +30,7 @@ except ModuleNotFoundError:
     pass
 
 from prefect.blocks.core import Block
-from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 
 
 def _raise_help_msg(key: str):
@@ -153,6 +153,7 @@ class GcpCredentials(Block):
             credentials, _ = google.auth.default()
         return credentials
 
+    @sync_compatible
     async def get_access_token(self):
         """
         See: https://stackoverflow.com/a/69107745

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,9 +167,18 @@ class SecretManagerClient:
 @pytest.fixture
 def mock_credentials(monkeypatch):
     mock_credentials = MagicMock(name="MockGoogleCredentials")
+    mock_authenticated_credentials = MagicMock(token="my-token")
+    mock_credentials.from_service_account_info = mock_authenticated_credentials
+    mock_credentials.from_service_account_file = mock_authenticated_credentials
     monkeypatch.setattr(
-        "prefect_gcp.cloud_run.GcpCredentials.get_credentials_from_service_account",  # noqa
+        "prefect_gcp.credentials.Credentials",  # noqa
         mock_credentials,
+    )
+    mock_auth = MagicMock()
+    mock_auth.default.return_value = (mock_authenticated_credentials, "project")
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.google.auth",  # noqa
+        mock_auth,
     )
     return mock_credentials
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -196,3 +196,14 @@ def test_credentials_is_able_to_serialize_back(monkeypatch, service_account_info
         }
     }
     assert test_flow() == expected
+
+
+async def test_get_access_token_async(gcp_credentials):
+    print(gcp_credentials.get_credentials_from_service_account().token)
+    token = await gcp_credentials.get_access_token()
+    assert token == "my-token"
+
+
+def test_get_access_token_sync_compatible(gcp_credentials):
+    token = gcp_credentials.get_access_token()
+    assert token == "my-token"


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Looking at https://github.com/PrefectHQ/prefect-dbt/pull/100, and I realized we already have a built-in method for this. However, this is async and I think it can be sync compatible.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
