### PR TITLE
Adds handling for `service_account_info` provided as a json formatted string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.1
+
+Released on December 23rd, 2022.
+
+### Changed
+
+- Adds handling for ` service_account_info` supplied to `GcpCredentials` as a json formatted string - [#94](https://github.com/PrefectHQ/prefect-gcp/pull/94)
+
 ## 0.2.0
 
 Released on December 22nd, 2022.

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -140,7 +140,10 @@ class GcpCredentials(CredentialsBlock):
 
     @validator("service_account_info", pre=True)
     def _convert_json_string_json_service_account_info(cls, value):
-        """Converts service account info provided as a json formatted string to a dictionary"""
+        """
+        Converts service account info provided as a json formatted string
+        to a dictionary
+        """
         if isinstance(value, str):
             try:
                 service_account_info = json.loads(value)

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -140,6 +140,7 @@ class GcpCredentials(CredentialsBlock):
 
     @validator("service_account_info", pre=True)
     def _convert_json_string_json_service_account_info(cls, value):
+        """Converts service account info provided as a json formatted string to a dictionary"""
         if isinstance(value, str):
             try:
                 service_account_info = json.loads(value)

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -1,6 +1,7 @@
 """Module handling GCP credentials."""
 
 import functools
+import json
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
@@ -136,6 +137,17 @@ class GcpCredentials(CredentialsBlock):
         if not service_account_file.exists():
             raise ValueError("The provided path to the service account is invalid")
         return service_account_file
+
+    @validator("service_account_info", pre=True)
+    def _convert_json_string_json_service_account_info(cls, value):
+        if isinstance(value, str):
+            try:
+                service_account_info = json.loads(value)
+                return service_account_info
+            except Exception:
+                raise ValueError("Unable to decode service_account_info")
+        else:
+            return value
 
     def block_initialization(self):
         credentials = self.get_credentials_from_service_account()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,10 +271,12 @@ def service_account_info_json(monkeypatch):
         "google.auth.crypt._cryptography_rsa.serialization.load_pem_private_key",
         lambda *args, **kwargs: args[0],
     )
-    _service_account_info = json.dumps({
-        "project_id": "my_project",
-        "token_uri": "my-token-uri",
-        "client_email": "my-client-email",
-        "private_key": "my-private-key",
-    })
+    _service_account_info = json.dumps(
+        {
+            "project_id": "my_project",
+            "token_uri": "my-token-uri",
+            "client_email": "my-client-email",
+            "private_key": "my-private-key",
+        }
+    )
     return _service_account_info

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -261,4 +262,19 @@ def service_account_info(monkeypatch):
         "client_email": "my-client-email",
         "private_key": "my-private-key",
     }
+    return _service_account_info
+
+
+@pytest.fixture()
+def service_account_info_json(monkeypatch):
+    monkeypatch.setattr(
+        "google.auth.crypt._cryptography_rsa.serialization.load_pem_private_key",
+        lambda *args, **kwargs: args[0],
+    )
+    _service_account_info = json.dumps({
+        "project_id": "my_project",
+        "token_uri": "my-token-uri",
+        "client_email": "my-client-email",
+        "private_key": "my-private-key",
+    })
     return _service_account_info

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -64,6 +64,21 @@ def test_get_credentials_from_service_account_file_error(oauth2_credentials):
         ).get_credentials_from_service_account()
 
 
+def test_able_to_load_credentials_from_json_string(service_account_info_json):
+    gcp_credentials = GcpCredentials(service_account_info=service_account_info_json)
+    assert gcp_credentials.service_account_info.get_secret_value() == {
+        "project_id": "my_project",
+        "token_uri": "my-token-uri",
+        "client_email": "my-client-email",
+        "private_key": "my-private-key",
+    }
+
+
+def test_raise_on_invalid_json_credentials():
+    with pytest.raises(ValueError):
+        GcpCredentials(service_account_info="not json")
+
+
 def test_get_credentials_from_service_account_both_error(
     service_account_info, oauth2_credentials
 ):


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Adds a validator to convert `service_account_info` from a json string to a dict. This change mitigates the type change on the block introduced in 0.2.0.

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
