### PR TITLE
Cloud Run task timeouts should be inferred from CloudRunJob params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `CloudRunJob` timeout parameter is now passed to the GCP TaskSpec. This allows Cloud Run tasks to run for longer than their default of 10min. [#99](https://github.com/PrefectHQ/prefect-gcp/pull/99)
+
 ### Deprecated
 
 ### Removed

--- a/prefect_gcp/cloud_run.py
+++ b/prefect_gcp/cloud_run.py
@@ -570,6 +570,9 @@ class CloudRunJob(Infrastructure):
         # env and command here
         containers = [self._add_container_settings({"image": self.image})]
 
+        # apply this timeout to each task
+        timeout_seconds = str(self.timeout or 600)  # default to 10min
+
         body = {
             "apiVersion": "run.googleapis.com/v1",
             "kind": "Job",
@@ -578,7 +581,10 @@ class CloudRunJob(Infrastructure):
                 "template": {  # ExecutionTemplateSpec
                     "spec": {  # ExecutionSpec
                         "template": {  # TaskTemplateSpec
-                            "spec": {"containers": containers}  # TaskSpec
+                            "spec": {
+                                "containers": containers,
+                                "timeoutSeconds": timeout_seconds,
+                            }  # TaskSpec
                         }
                     },
                 }

--- a/prefect_gcp/cloud_run.py
+++ b/prefect_gcp/cloud_run.py
@@ -277,7 +277,9 @@ class CloudRunJob(Infrastructure):
         description="Keep the completed Cloud Run Job on Google Cloud Platform.",
     )
     timeout: Optional[int] = Field(
-        default=None,
+        default=600,
+        gt=0,
+        le=3600,
         title="Job Timeout",
         description=(
             "The length of time that Prefect will wait for a Cloud Run Job to complete "
@@ -571,7 +573,7 @@ class CloudRunJob(Infrastructure):
         containers = [self._add_container_settings({"image": self.image})]
 
         # apply this timeout to each task
-        timeout_seconds = str(self.timeout or 600)  # default to 10min
+        timeout_seconds = str(self.timeout)
 
         body = {
             "apiVersion": "run.googleapis.com/v1",

--- a/tests/test_cloud_run.py
+++ b/tests/test_cloud_run.py
@@ -494,6 +494,14 @@ class TestCloudRunJobContainerSettings:
             "requests": {"cpu": expected_cpu, "memory": str(memory) + memory_unit},
         }
 
+    def test_timeout_added_correctly(self, cloud_run_job):
+        timeout = 10
+        cloud_run_job.timeout = timeout
+        result = cloud_run_job._jobs_body()
+        assert result["spec"]["template"]["spec"]["template"]["spec"][
+            "timeoutSeconds"
+        ] == str(timeout)
+
     def test_memory_validation_succeeds(self, gcp_credentials):
         """Make sure that memory validation doesn't fail when valid params provided."""
         CloudRunJob(


### PR DESCRIPTION

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

### Overview

Closes https://github.com/PrefectHQ/prefect-gcp/issues/97

Currently, a Cloud Run task can not run longer than 10min without being shut down by GCP. Inferring the parameter from `CloudRunJob.timeout` has the advantage:
- For a job having any number of tasks, the individual cloud run task timeouts will be inherited from the prefect job timeout.

but the disadvantage:
- You cannot set the job timeout longer than 3600 seconds (1 hour) because that is the upper limit on cloud run tasks.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```python
cloud_run_job_block = CloudRunJob(
    image='',
    region='',
    credentials='',
    timeout=3600  # 1 hour
)
```

From the [CloudRun task timeout docs](https://cloud.google.com/run/docs/configuring/task-timeout):
```
By default, each task runs for a maximum of 10 minutes: you can change this to a shorter time or a longer time up to 1 hour.
```

See attached example: [example.zip](https://github.com/PrefectHQ/prefect-gcp/files/10316930/example.zip)



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
