### PR TITLE
returns list of downloaded file paths at GcsBucket#get_directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `get_directory` method in `GcsBucket` returns the list of downloaded file paths and supports relative path for `local_path`.
+
 ### Deprecated
 
 ### Removed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,9 +88,8 @@ class CloudStorageClient:
         nested_blob_obj = Blob(name="base_folder/nested_blob.txt")
         double_nested_blob_obj = Blob(name="base_folder/sub_folder/nested_blob.txt")
         blobs = [blob_obj, blob_directory, nested_blob_obj, double_nested_blob_obj]
-        for blob in blobs:
-            if prefix and not blob.name.startswith(prefix):
-                blobs.remove(blob)
+        if prefix:
+            blobs = [blob for blob in blobs if blob.name.startswith(prefix)]
         return blobs
 
 

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -151,14 +151,15 @@ class TestGcsBucket:
         assert gcs_bucket.write_path("blob", b"bytes_data") == f"{bucket_folder}blob"
 
     @pytest.mark.parametrize("from_path", [None, "base_folder", "sub_folder"])
-    @pytest.mark.parametrize("local_path", [None])
+    @pytest.mark.parametrize("local_path", [None, "local_path"])
     def test_get_directory(self, gcs_bucket, tmp_path, from_path, local_path):
         os.chdir(tmp_path)
 
-        local_path = os.path.abspath(".")
-        prefix = os.path.join(gcs_bucket.bucket_folder, from_path or "")
-
         actual = gcs_bucket.get_directory(from_path=from_path, local_path=local_path)
+
+        prefix = os.path.join(gcs_bucket.bucket_folder, from_path or "")
+        if local_path is None:
+            local_path = os.path.abspath(".")
 
         if from_path is None:
             from_path = gcs_bucket.bucket_folder
@@ -227,7 +228,7 @@ class TestGcsBucket:
         assert set(blobs) == {"base_folder", "base_folder/sub_folder"}
 
     def test_list_folders_with_sub_folders(self, gcs_bucket_with_bucket_folder):
-        blobs = gcs_bucket_with_bucket_folder.list_folders("base_folder")
+        blobs = gcs_bucket_with_bucket_folder.list_folders("sub_folder/")
         assert len(blobs) == 1
         assert blobs[0] == "base_folder/sub_folder"
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

This PR improves `GcsBucket#get_directory` method.
- returns the list of downloaded file paths.
- support relative path for `local_path`

and fix the behavior of the `list_blobs` test fixture.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```python
downloaded_file_paths = bucket.get_directory()
```

### Screenshots

![screenshot](https://user-images.githubusercontent.com/7046371/216362137-ee6ab35f-b623-483e-b93a-aff9c9f1571e.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
