### PR TITLE
Pass infra base environment settings from Agent to Vertex job

### DIFF
--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -204,7 +204,13 @@ class VertexAICustomTrainingJob(Infrastructure):
         Builds a job spec by gathering details.
         """
         # gather worker pool spec
-        env_list = [{"name": name, "value": value} for name, value in self.env.items()]
+        env_list = [
+            {"name": name, "value": value}
+            for name, value in {
+                **self._base_environment(),
+                **self.env,
+            }.items()
+        ]
         container_spec = ContainerSpec(
             image_uri=self.image, command=self.command, args=[], env=env_list
         )

--- a/tests/test_aiplatform.py
+++ b/tests/test_aiplatform.py
@@ -23,29 +23,60 @@ class TestVertexAICustomTrainingJob:
     # TODO: Improve test resiliency to changes in str output
     def test_preview(self, vertex_ai_custom_training_job: VertexAICustomTrainingJob):
         actual_lines = vertex_ai_custom_training_job.preview().splitlines()
-        expected_lines = """
+
+        base_env = VertexAICustomTrainingJob._base_environment().copy()
+        env_lines = [
+            f'env {{\n        name: "{name}"\n        value: "{value}"\n      }}'
+            for name, value in base_env.items()
+        ]
+        env_str = "\n".join(env_lines)
+
+        expected_lines = f"""
             display_name: "container
-            job_spec {
-                worker_pool_specs {
-                    container_spec {
+            job_spec {{
+                worker_pool_specs {{
+                    container_spec {{
                         image_uri: "us-docker.pkg.dev/cloudrun/container/job:latest"
                         command: "echo"
                         command: "hello!!"
-                    }
-                    machine_spec {
+                        {env_str}
+                    }}
+                    machine_spec {{
                         machine_type: "n1-standard-4"
-                    }
+                    }}
                     replica_count: 1
-                }
-                scheduling {
-                }
+                }}
+                scheduling {{
+                }}
                 service_account: "my_service_account_email"
-            }
+            }}
         """.strip().splitlines()
+
         for actual_line, expected_line in zip(actual_lines, expected_lines):
             if '"container' in actual_line:
                 actual_line = actual_line.split("-")[0]  # remove the unique hex
             assert actual_line.strip() == expected_line.strip()  # disregard whitespace
+
+    def test_environment_variables(self, gcp_credentials):
+        vertex_job = VertexAICustomTrainingJob(
+            command=["echo", "hello!!"],
+            region="us-east1",
+            image="us-docker.pkg.dev/cloudrun/container/job:latest",
+            gcp_credentials=gcp_credentials,
+            env={"FOO": "BAR"},
+        )
+        job_spec = vertex_job._build_job_spec()
+
+        assert len(job_spec.worker_pool_specs) == 1
+
+        env_list_in_container_spec = job_spec.worker_pool_specs[0].container_spec.env
+
+        expected_env = VertexAICustomTrainingJob._base_environment().copy()
+        expected_env.update({"FOO": "BAR"})
+
+        for item in env_list_in_container_spec:
+            assert item.name in expected_env
+            assert item.value == expected_env[item.name]
 
     def test_kill(
         self, vertex_ai_custom_training_job: VertexAICustomTrainingJob, caplog

--- a/tests/test_aiplatform.py
+++ b/tests/test_aiplatform.py
@@ -9,9 +9,6 @@ from prefect_gcp.aiplatform import (
     VertexAICustomTrainingJobResult,
 )
 
-# @patch("VertexAICustomTrainingJob._base_environment")
-# mock_base_env.return_value = {"PREFECT_API_KEY": "secret"}
-
 
 class TestVertexAICustomTrainingJob:
     @pytest.fixture


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

The Vertex agent does not currently set the Prefect API URL or API Key when the Vertex job is launched. This means the launched Vertex job cannot report the state to the Prefect API. This is probably an oversight because:
1. This used to be set in Prefect 1.x VertexAgent: https://github.com/slate-data/prefect/blob/a6c930403642c35d34d2ccb4b508cc85ce0566aa/src/prefect/agent/vertex/agent.py#L215 
2. This is currently set in the `prefect-aws/ecs.py -> ECSTask`:  https://github.com/PrefectHQ/prefect-aws/blob/6fe4c564dc865e3500e663a99b346fb515222d07/prefect_aws/ecs.py#L1344 

Changes:
- Add base env variables to pass settings from agent to Vertex job
- Fix test_preview by adding in the `env` string

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
Tested this out and it adds in the 2 profile env vars as expected - `PREFECT_API_URL` & `PREFECT_API_KEY`.

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
