### PR TITLE
Feature: GcsBucket.upload_from_dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-  `upload_from_dataframe` method in `GcsBucket` - [#140](https://github.com/PrefectHQ/prefect-gcp/pull/140)
+
 ### Changed
 
 ### Deprecated

--- a/prefect_gcp/cloud_storage.py
+++ b/prefect_gcp/cloud_storage.py
@@ -1159,10 +1159,13 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             df (pd.DataFrame): pandas Dataframe object
             to_path (str): the actual full blob name (e.g.: /path/to/gcs/blob.csv)
             output_format (str): Specify whether the output should be csv or parquet
-            compression (Optional[str], optional): Specify the compression type
+            compression (Optional[str], optional):
+                Specify the compression type for the output.
                 'csv' supports 'None' or 'gzip',
                 'parquet' supports 'None', 'snappy', 'gzip'.
                 Defaults to None.
+            **upload_kwargs: Additional keyword arguments to pass to
+                `Blob.upload_from_file`.
 
         Returns:
             The path that the folder was uploaded to.
@@ -1205,8 +1208,10 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             )
 
         byte_buffer.seek(0)
-        return await self.upload_from_file_object(
+        gcs_path = await self.upload_from_file_object(
             from_file_object=byte_buffer,
             to_path=to_path,
-            **{"content_type": content_type},
+            **{"content_type": content_type, **upload_kwargs},
         )
+        byte_buffer.close()
+        return gcs_path

--- a/prefect_gcp/cloud_storage.py
+++ b/prefect_gcp/cloud_storage.py
@@ -1156,16 +1156,15 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
             .csv, .csv.gz, .parquet, .parquet.snappy, .parquet.gz
 
         Args:
-            df (pd.DataFrame): pandas Dataframe object
-            to_path (str): the actual full blob name (e.g.: /path/to/gcs/blob.csv)
-            output_format (str): Specify whether the output should be csv or parquet
-            compression (Optional[str], optional):
-                Specify the compression type for the output.
+            df: The pandas Dataframe object to upload.
+            to_path: The path to upload the object to; this gets prefixed
+                with the bucket_folder.
+            output_format: The output format to serialize the dataframe into.
+            compression: Specify the compression type for the output.
                 'csv' supports 'None' or 'gzip',
                 'parquet' supports 'None', 'snappy', 'gzip'.
-                Defaults to None.
             **upload_kwargs: Additional keyword arguments to pass to
-                `Blob.upload_from_file`.
+                `Blob.upload_from_dataframe`.
 
         Returns:
             The path that the folder was uploaded to.
@@ -1177,7 +1176,7 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
 
             gcs_bucket = GcsBucket.load("my-bucket")
             gcs_bucket.upload_from_dataframe(
-                df=pandas_df, blob_name="/path/to/gcs/blob.parquet",
+                df=pandas_df, to_path="/path/to/gcs/blob.parquet",
                 output='parquet', compression='snappy'
             )
             ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+pandas
+pyarrow
 pytest
 black
 flake8

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -473,9 +473,9 @@ class TestGcsBucket:
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
             df=pandas_dataframe, to_path=to_path
         )
-        assert output_to_path == "base_folder/to_path.parquet"
+        assert output_to_path == "base_folder/to_path.csv.gz"
 
-    def test_upload_from_dataframe_parquet_output_unspecified_compression(
+    def test_upload_from_dataframe_with_parquet_output(
         self, gcs_bucket_with_bucket_folder, pandas_dataframe
     ):
         to_path = "to_path"
@@ -484,43 +484,29 @@ class TestGcsBucket:
         )
         assert output_to_path == "base_folder/to_path.parquet"
 
-    def test_upload_from_dataframe_with_parquet_output_no_compression(
+    def test_upload_from_dataframe_with_parquet_snappy_output(
         self, gcs_bucket_with_bucket_folder, pandas_dataframe
     ):
         to_path = "to_path"
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
             df=pandas_dataframe,
             to_path=to_path,
-            output_format="parquet",
-            compression=None,
-        )
-        assert output_to_path == "base_folder/to_path.parquet"
-
-    def test_upload_from_dataframe_with_parquet_output_gzip_compression(
-        self, gcs_bucket_with_bucket_folder, pandas_dataframe
-    ):
-        to_path = "to_path"
-        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe,
-            to_path=to_path,
-            output_format="parquet",
-            compression="gzip",
-        )
-        assert output_to_path == "base_folder/to_path.parquet.gz"
-
-    def test_upload_from_dataframe_with_parquet_output_snappy_compression(
-        self, gcs_bucket_with_bucket_folder, pandas_dataframe
-    ):
-        to_path = "to_path"
-        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe,
-            to_path=to_path,
-            output_format="parquet",
-            compression="snappy",
+            output_format="parquet_snappy",
         )
         assert output_to_path == "base_folder/to_path.parquet.snappy"
 
-    def test_upload_from_dataframe_with_csv_output_unspecified_compression(
+    def test_upload_from_dataframe_with_parquet_gzip_output(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe,
+            to_path=to_path,
+            output_format="parquet_gzip",
+        )
+        assert output_to_path == "base_folder/to_path.parquet.gz"
+
+    def test_upload_from_dataframe_with_csv_output(
         self, gcs_bucket_with_bucket_folder, pandas_dataframe
     ):
         to_path = "to_path"
@@ -529,32 +515,21 @@ class TestGcsBucket:
         )
         assert output_to_path == "base_folder/to_path.csv"
 
-    def test_upload_from_dataframe_with_csv_output_no_compression(
+    def test_upload_from_dataframe_with_csv_gzip_output(
         self, gcs_bucket_with_bucket_folder, pandas_dataframe
     ):
         to_path = "to_path"
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe, to_path=to_path, output_format="csv", compression=None
-        )
-        assert output_to_path == "base_folder/to_path.csv"
-
-    def test_upload_from_dataframe_with_csv_output_gzip_compressed(
-        self, gcs_bucket_with_bucket_folder, pandas_dataframe
-    ):
-        to_path = "to_path"
-        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe,
-            to_path=to_path,
-            output_format="csv",
-            compression="gzip",
+            df=pandas_dataframe, to_path=to_path, output_format="csv_gzip"
         )
         assert output_to_path == "base_folder/to_path.csv.gz"
 
-    def test_upload_from_dataframe_with_unsupported_output(
+    def test_upload_from_dataframe_with_invalid_output_falls_back_to_csv_gzip(
         self, gcs_bucket_with_bucket_folder, pandas_dataframe
     ):
         to_path = "to_path"
-        with pytest.raises(RuntimeError):
-            gcs_bucket_with_bucket_folder.upload_from_dataframe(
-                df=pandas_dataframe, to_path=to_path, output_format="pickle"
-            )
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe, to_path=to_path, output_format="pickle"
+        )
+
+        assert output_to_path == "base_folder/to_path.csv.gz"

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -524,12 +524,11 @@ class TestGcsBucket:
         )
         assert output_to_path == "base_folder/to_path.csv.gz"
 
-    def test_upload_from_dataframe_with_invalid_output_falls_back_to_csv_gzip(
+    def test_upload_from_dataframe_with_invalid_serialization_should_raise_key_error(
         self, gcs_bucket_with_bucket_folder, pandas_dataframe
     ):
-        to_path = "to_path"
-        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe, to_path=to_path, serialization_format="pickle"
-        )
-
-        assert output_to_path == "base_folder/to_path.csv.gz"
+        with pytest.raises(KeyError):
+            to_path = "to_path"
+            gcs_bucket_with_bucket_folder.upload_from_dataframe(
+                df=pandas_dataframe, to_path=to_path, serialization_format="pickle"
+            )

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from pathlib import Path, PurePosixPath
 from uuid import UUID
 
+import pandas as pd
 import pytest
 from prefect import flow
 
@@ -220,6 +221,15 @@ class TestGcsBucket:
             bucket="bucket",
             gcp_credentials=gcp_credentials,
             bucket_folder=request.param,
+        )
+
+    @pytest.fixture
+    def pandas_dataframe(self):
+        return pd.DataFrame.from_dict(
+            {
+                "name": ["John Doe", "Jane Doe", "Johny", "Jane"],
+                "username": ["john.doe", "jane.doe", "johny", "jane"],
+            }
         )
 
     def test_list_folders_with_root_only(self, gcs_bucket_with_bucket_folder):
@@ -455,3 +465,96 @@ class TestGcsBucket:
             from_path, "to_path"
         )
         assert output_to_path == "base_folder/to_path"
+
+    def test_upload_from_dataframe_with_default_options(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe, to_path=to_path
+        )
+        assert output_to_path == "base_folder/to_path.parquet"
+
+    def test_upload_from_dataframe_parquet_output_unspecified_compression(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe, to_path=to_path, output_format="parquet"
+        )
+        assert output_to_path == "base_folder/to_path.parquet"
+
+    def test_upload_from_dataframe_with_parquet_output_no_compression(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe,
+            to_path=to_path,
+            output_format="parquet",
+            compression=None,
+        )
+        assert output_to_path == "base_folder/to_path.parquet"
+
+    def test_upload_from_dataframe_with_parquet_output_gzip_compression(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe,
+            to_path=to_path,
+            output_format="parquet",
+            compression="gzip",
+        )
+        assert output_to_path == "base_folder/to_path.parquet.gz"
+
+    def test_upload_from_dataframe_with_parquet_output_snappy_compression(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe,
+            to_path=to_path,
+            output_format="parquet",
+            compression="snappy",
+        )
+        assert output_to_path == "base_folder/to_path.parquet.snappy"
+
+    def test_upload_from_dataframe_with_csv_output_unspecified_compression(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe, to_path=to_path, output_format="csv"
+        )
+        assert output_to_path == "base_folder/to_path.csv"
+
+    def test_upload_from_dataframe_with_csv_output_no_compression(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe, to_path=to_path, output_format="csv", compression=None
+        )
+        assert output_to_path == "base_folder/to_path.csv"
+
+    def test_upload_from_dataframe_with_csv_output_gzip_compressed(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
+            df=pandas_dataframe,
+            to_path=to_path,
+            output_format="csv",
+            compression="gzip",
+        )
+        assert output_to_path == "base_folder/to_path.csv.gz"
+
+    def test_upload_from_dataframe_with_unsupported_output(
+        self, gcs_bucket_with_bucket_folder, pandas_dataframe
+    ):
+        to_path = "to_path"
+        with pytest.raises(RuntimeError):
+            gcs_bucket_with_bucket_folder.upload_from_dataframe(
+                df=pandas_dataframe, to_path=to_path, output_format="pickle"
+            )

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -480,7 +480,7 @@ class TestGcsBucket:
     ):
         to_path = "to_path"
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe, to_path=to_path, output_format="parquet"
+            df=pandas_dataframe, to_path=to_path, serialization_format="parquet"
         )
         assert output_to_path == "base_folder/to_path.parquet"
 
@@ -491,7 +491,7 @@ class TestGcsBucket:
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
             df=pandas_dataframe,
             to_path=to_path,
-            output_format="parquet_snappy",
+            serialization_format="parquet_snappy",
         )
         assert output_to_path == "base_folder/to_path.parquet.snappy"
 
@@ -502,7 +502,7 @@ class TestGcsBucket:
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
             df=pandas_dataframe,
             to_path=to_path,
-            output_format="parquet_gzip",
+            serialization_format="parquet_gzip",
         )
         assert output_to_path == "base_folder/to_path.parquet.gz"
 
@@ -511,7 +511,7 @@ class TestGcsBucket:
     ):
         to_path = "to_path"
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe, to_path=to_path, output_format="csv"
+            df=pandas_dataframe, to_path=to_path, serialization_format="csv"
         )
         assert output_to_path == "base_folder/to_path.csv"
 
@@ -520,7 +520,7 @@ class TestGcsBucket:
     ):
         to_path = "to_path"
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe, to_path=to_path, output_format="csv_gzip"
+            df=pandas_dataframe, to_path=to_path, serialization_format="csv_gzip"
         )
         assert output_to_path == "base_folder/to_path.csv.gz"
 
@@ -529,7 +529,7 @@ class TestGcsBucket:
     ):
         to_path = "to_path"
         output_to_path = gcs_bucket_with_bucket_folder.upload_from_dataframe(
-            df=pandas_dataframe, to_path=to_path, output_format="pickle"
+            df=pandas_dataframe, to_path=to_path, serialization_format="pickle"
         )
 
         assert output_to_path == "base_folder/to_path.csv.gz"


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
### Overview
- Implements `upload_from_dataframe` as proposed on [#139 ](https://github.com/PrefectHQ/prefect-gcp/issues/139)
- Enables the DataFrame persistence on GCS as `.csv`, `.csv.gz`, `.parquet`, `.parquet.snappy`, `.parquet.gz`
- When the `serialization_format` is not specified, it defaults to `.csv.gz` (csv with 'gzip' compression)

**Closes**:
[Upload pandas DataFrame to GoogleCloudStorageBucket #139 ](https://github.com/PrefectHQ/prefect-gcp/issues/139)

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```python
import pandas as pd
from prefect_gcp.cloud_storage import GcsBucket

pandas_df = pd.read_csv(url="some_url")

gcs_bucket = GcsBucket.load("my-bucket")
gcs_bucket.upload_from_dataframe(
   df=pandas_df, 
   to_path="/path/to/gcs/blob.parquet", 
   serialization_format='parquet_snappy'
)
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
