### PR TITLE
Added a note that discourages the use of service_account_file in favor of service_account_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ GcpCredentials(
 ).save("BLOCK_NAME_PLACEHOLDER")
 ```
 
+> **_NOTE:_**  The use of service_account_file is discouraged since it is not portable with containers. Please use service_account_info instead.
+
+
 Congrats! You can now easily load the saved block, which holds your credentials:
 
 ```python
@@ -70,6 +73,8 @@ GcpCredentials.load("BLOCK_NAME_PLACEHOLDER")
     ```bash
     prefect block register -m prefect_gcp
     ```
+
+
 
 ### Download blob from bucket
 


### PR DESCRIPTION
Using service_account_file can cause portability issue when using containers. service_account_info should be used instead.

### Example

### Screenshots

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - Closes <https://github.com/PrefectHQ/prefect-gcp/issues/119>
- [ ] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
