### PR TITLE
Fix file extensions for compressed parquet (.gz.parquet & .snappy.parquet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - [Fix `upload_from_dataframe` docstring for MkDocs](https://github.com/PrefectHQ/prefect-gcp/pull/162) 
+- [Fix `upload_from_dataframe` file extensions for compressed parquet ('.snappy.parquet', '.gz.parquet')](https://github.com/PrefectHQ/prefect-gcp/pull/166)
 
 ### Added
 

--- a/prefect_gcp/cloud_storage.py
+++ b/prefect_gcp/cloud_storage.py
@@ -502,9 +502,9 @@ class DataFrameSerializationFormat(Enum):
         "parquet",
         "snappy",
         "application/octet-stream",
-        ".parquet.snappy",
+        ".snappy.parquet",
     )
-    PARQUET_GZIP = ("parquet", "gzip", "application/octet-stream", ".parquet.gz")
+    PARQUET_GZIP = ("parquet", "gzip", "application/octet-stream", ".gz.parquet")
 
     @property
     def format(self) -> str:

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -495,7 +495,7 @@ class TestGcsBucket:
             to_path=to_path,
             serialization_format="parquet_snappy",
         )
-        assert output_to_path == "base_folder/to_path.parquet.snappy"
+        assert output_to_path == "base_folder/to_path.snappy.parquet"
 
     def test_upload_from_dataframe_with_parquet_gzip_output(
         self, gcs_bucket_with_bucket_folder, pandas_dataframe
@@ -506,7 +506,7 @@ class TestGcsBucket:
             to_path=to_path,
             serialization_format="parquet_gzip",
         )
-        assert output_to_path == "base_folder/to_path.parquet.gz"
+        assert output_to_path == "base_folder/to_path.gz.parquet"
 
     def test_upload_from_dataframe_with_csv_output(
         self, gcs_bucket_with_bucket_folder, pandas_dataframe


### PR DESCRIPTION
### Summary 

* Fix file-extension to '.snappy.parquet' from 'parquet.snappy', when using the 'parquet_snappy' serialization fmt
* Fix file-extension to '.gz.parquet' from 'parquet.gz' when using the 'parquet_gzip' serialization format
* Fix pytests accordingly to expect the new file extensions

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

### Closes
[Issue #165](https://github.com/PrefectHQ/prefect-gcp/issues/165)


### Example
Code-wise, this changes is very transparent to our user base, as nothing changes

```python
import pandas as pd
from prefect_gcp.cloud_storage import GcsBucket

pandas_df = pd.read_csv(url="some_url")

gcs_bucket = GcsBucket.load("my-bucket")
gcs_bucket.upload_from_dataframe(
   df=pandas_df, 
   to_path="/path/to/gcs/blob.parquet", 
   serialization_format='parquet_gz'
)
```


### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
