### PR TITLE
Adds `pull_project_from_gcs` and `push_project_to_gcs` steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `pull_project_from_gcs` and `push_project_to_gcs` steps - [#167](https://github.com/PrefectHQ/prefect-gcp/pull/167)
+
 ### Changed
 
 ### Deprecated

--- a/prefect_gcp/projects/steps.py
+++ b/prefect_gcp/projects/steps.py
@@ -1,0 +1,238 @@
+from pathlib import Path, PurePosixPath
+from typing import Dict, Optional
+
+import google.auth
+from google.cloud.storage import Client as StorageClient
+from google.oauth2.service_account import Credentials
+from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
+from typing_extensions import TypedDict
+
+
+class PushProjectToGcsOutput(TypedDict):
+    """
+    The output of the `push_project_to_gcs` step.
+    """
+
+    bucket: str
+    folder: str
+
+
+class PullProjectFromGcsOutput(TypedDict):
+    """
+    The output of the `pull_project_from_gcs` step.
+    """
+
+    bucket: str
+    folder: str
+    directory: str
+
+
+def push_project_to_gcs(
+    bucket: str,
+    folder: str,
+    credentials: Optional[Dict] = None,
+    ignore_file=".prefectignore",
+) -> PushProjectToGcsOutput:
+    """
+    Pushes the contents of the current working directory to an S3 bucket,
+    excluding files and folders specified in the ignore_file.
+
+    Args:
+        bucket: The name of the S3 bucket where the project files will be uploaded.
+        folder: The folder in the S3 bucket where the project files will be uploaded.
+        project: The project the bucket belongs to.
+        credentials: A dictionary containing the service account information and project
+            used for authentication. If not provided, the application default
+            credentials will be used.
+        ignore_file: The name of the file containing ignore patterns.
+
+    Returns:
+        A dictionary containing the bucket and folder where the project was uploaded.
+
+    Examples:
+        Push a project to an GCS bucket:
+        ```yaml
+        build:
+            - prefect_gcp.projects.steps.push_project_to_gcs:
+                requires: prefect-gcp
+                bucket: my-bucket
+                folder: my-project
+                project: my-project
+        ```
+
+        Push a project to an GCS bucket using credentials stored in a block:
+        ```yaml
+        build:
+            - prefect_gcp.projects.steps.push_project_to_gcs:
+                requires: prefect-gcp
+                bucket: my-bucket
+                folder: my-project
+                project: my-project
+                credentials: "{{ prefect.blocks.gcp-credentials.dev-credentials }}"
+        ```
+
+        Push a project to an GCS bucket using credentials stored in a block:
+        ```yaml
+        build:
+            - prefect_gcp.projects.steps.push_project_to_gcs:
+                requires: prefect-gcp
+                bucket: my-bucket
+                folder: my-project
+                project: my-project
+                credentials: "{{ prefect.blocks.gcp-credentials.dev-credentials }}"
+        ```
+
+        Push a project to an GCS bucket using credentials stored in a service account
+        file:
+        ```yaml
+        build:
+            - prefect_gcp.projects.steps.push_project_to_gcs:
+                requires: prefect-gcp
+                bucket: my-bucket
+                folder: my-project
+                project: my-project
+                credentials:
+                    project: my-project
+                    service_account_file: /path/to/service_account.json
+        ```
+
+    """
+    project = credentials.get("project") if credentials else None
+    if credentials is None:
+        gcp_creds, _ = google.auth.default()
+    elif credentials.get("service_account_info") is not None:
+        gcp_creds = Credentials.from_service_account_info(
+            credentials.get("service_account_info"),
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+    elif credentials.get("service_account_file") is not None:
+        gcp_creds = Credentials.from_service_account_file(
+            credentials.get("service_account_file"),
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+    else:
+        gcp_creds, _ = google.auth.default()
+
+    storage_client = StorageClient(credentials=gcp_creds, project=project)
+    bucket_resource = storage_client.bucket(bucket)
+
+    local_path = Path.cwd()
+
+    included_files = None
+    if ignore_file and Path(ignore_file).exists():
+        with open(ignore_file, "r") as f:
+            ignore_patterns = f.readlines()
+        included_files = filter_files(str(local_path), ignore_patterns)
+
+    for local_file_path in Path(local_path).rglob("*"):
+        if included_files is not None and local_file_path.name not in included_files:
+            continue
+        elif not local_file_path.is_dir():
+            remote_file_path = (
+                folder / local_file_path.relative_to(local_path)
+            ).as_posix()
+
+            blob_resource = bucket_resource.blob(remote_file_path)
+            blob_resource.upload_from_filename(local_file_path)
+
+    return {
+        "bucket": bucket,
+        "folder": folder,
+    }
+
+
+def pull_project_from_gcs(
+    bucket: str,
+    folder: str,
+    credentials: Optional[Dict] = None,
+) -> PullProjectFromGcsOutput:
+    """
+    Pulls the contents of a project from an GCS bucket to the current working directory.
+
+    Args:
+        bucket: The name of the GCS bucket where the project files are stored.
+        folder: The folder in the GCS bucket where the project files are stored.
+        project: The project the bucket belongs to.
+        credentials: A dictionary containing the service account information and project
+            used for authentication. If not provided, the application default
+            credentials will be used.
+
+    Returns:
+        A dictionary containing the bucket, folder, and local directory where the
+            project files were downloaded.
+
+    Examples:
+        Pull a project from GCS using the default environment credentials:
+        ```yaml
+        build:
+            - prefect_gcp.projects.steps.pull_project_from_gcs:
+                requires: prefect-gcp
+                bucket: my-bucket
+                folder: my-project
+                project: my-project
+        ```
+
+        Pull a project from GCS using credentials stored in a block:
+        ```yaml
+        build:
+            - prefect_gcp.projects.steps.pull_project_from_gcs:
+                requires: prefect-gcp
+                bucket: my-bucket
+                folder: my-project
+                project: my-project
+                credentials: "{{ prefect.blocks.gcp-credentials.dev-credentials }}"
+        ```
+
+        Pull from a project to an GCS bucket using credentials stored in a service account file:
+        ```yaml
+        build:
+            - prefect_gcp.projects.steps.pull_project_from_gcs:
+                requires: prefect-gcp
+                bucket: my-bucket
+                folder: my-project
+                project: my-project
+                credentials:
+                    project: my-project
+                    service_account_file: /path/to/service_account.json
+        ```
+
+    """  # noqa
+    local_path = Path.cwd()
+    project = credentials.get("project") if credentials else None
+
+    if credentials is None:
+        gcp_creds, _ = google.auth.default()
+    elif credentials.get("service_account_info") is not None:
+        gcp_creds = Credentials.from_service_account_info(
+            credentials.get("service_account_info"),
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+    elif credentials.get("service_account_file") is not None:
+        gcp_creds = Credentials.from_service_account_file(
+            credentials.get("service_account_file"),
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+    else:
+        gcp_creds, _ = google.auth.default()
+
+    storage_client = StorageClient(credentials=gcp_creds, project=project)
+
+    blobs = storage_client.list_blobs(bucket, prefix=folder)
+
+    for blob in blobs:
+        if blob.name.endswith("/"):
+            # object is a folder and will be created if it contains any objects
+            continue
+        target = PurePosixPath(
+            local_path
+            / relative_path_to_current_platform(blob.name).relative_to(folder)
+        )
+        Path.mkdir(Path(target.parent), parents=True, exist_ok=True)
+
+        blob.download_to_filename(target)
+
+    return {
+        "bucket": bucket,
+        "folder": folder,
+        "directory": str(local_path),
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 prefect>=2.7.2
 google-api-python-client>=2.20.0
+google-cloud-storage>=2.0.0

--- a/tests/projects/test_steps.py
+++ b/tests/projects/test_steps.py
@@ -1,0 +1,252 @@
+import json
+import os
+from pathlib import Path, PurePosixPath
+from unittest.mock import MagicMock
+
+import pytest
+from prefect.utilities.filesystem import relative_path_to_current_platform
+
+from prefect_gcp.projects.steps import pull_project_from_gcs, push_project_to_gcs
+
+
+@pytest.fixture
+def mock_credentials(monkeypatch):
+    mock_credentials = MagicMock(name="MockGoogleCredentials")
+    mock_authenticated_credentials = MagicMock(token="my-token")
+    mock_credentials.from_service_account_info = mock_authenticated_credentials
+    mock_credentials.from_service_account_file = mock_authenticated_credentials
+    monkeypatch.setattr(
+        "prefect_gcp.projects.steps.Credentials",  # noqa
+        mock_credentials,
+    )
+    mock_auth = MagicMock()
+    mock_auth.default.return_value = (mock_authenticated_credentials, "project")
+    monkeypatch.setattr(
+        "prefect_gcp.projects.steps.google.auth",  # noqa
+        mock_auth,
+    )
+    return mock_credentials
+
+
+@pytest.fixture
+def gcs_setup(monkeypatch, mock_credentials):
+    mocked_storage_client = MagicMock()
+    mocked_bucket = MagicMock()
+    mocked_blob = MagicMock()
+
+    mocked_storage_client.bucket.return_value = mocked_bucket
+    mocked_bucket.blob.return_value = mocked_blob
+
+    monkeypatch.setattr(
+        "prefect_gcp.projects.steps.StorageClient",
+        MagicMock(return_value=mocked_storage_client),
+    )
+    yield mocked_storage_client, mocked_bucket, mocked_blob
+
+
+@pytest.fixture
+def tmp_files(tmp_path: Path):
+    files = [
+        "testfile1.txt",
+        "testfile2.txt",
+        "testfile3.txt",
+        "testdir1/testfile4.txt",
+        "testdir2/testfile5.txt",
+    ]
+
+    (tmp_path / ".prefectignore").write_text(
+        """
+    testdir1/*
+    .prefectignore
+    """
+    )
+
+    for file in files:
+        filepath = tmp_path / file
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text("Sample text")
+
+    return tmp_path
+
+
+@pytest.fixture
+def dummy_service_account_info():
+    info = {
+        "type": "service_account",
+        "project_id": "dummy_project_id",
+        "private_key_id": "dummy_private_key_id",
+        "private_key": "dummy_private_key",
+        "client_email": "dummy_client_email",
+        "client_id": "dummy_client_id",
+        "auth_uri": "dummy_auth_uri",
+        "token_uri": "dummy_token_uri",
+        "auth_provider_x509_cert_url": "dummy_auth_provider_x509_cert_url",
+        "client_x509_cert_url": "dummy_client_x509_cert_url",
+    }
+    return info
+
+
+@pytest.fixture
+def dummy_service_account_file(tmp_path):
+    info = {
+        "type": "service_account",
+        "project_id": "dummy_project_id",
+        "private_key_id": "dummy_private_key_id",
+        "private_key": "dummy_private_key",
+        "client_email": "dummy_client_email",
+        "client_id": "dummy_client_id",
+        "auth_uri": "dummy_auth_uri",
+        "token_uri": "dummy_token_uri",
+        "auth_provider_x509_cert_url": "dummy_auth_provider_x509_cert_url",
+        "client_x509_cert_url": "dummy_client_x509_cert_url",
+    }
+    file = tmp_path / "dummy_service_account_file.json"
+    file.write_text(json.dumps(info))
+    return str(file)
+
+
+def test_push_project_to_gcs(gcs_setup, tmp_files, mock_credentials):
+    mocked_storage_client, mocked_bucket, mocked_blob = gcs_setup
+
+    bucket_name = "my-test-bucket"
+    folder = "my-project"
+
+    os.chdir(tmp_files)
+
+    push_project_to_gcs(bucket_name, folder)
+
+    # Assert that the StorageClient methods are called with the correct arguments
+    mocked_storage_client.bucket.assert_called_with(bucket_name)
+    assert mocked_bucket.blob.call_count == 4
+    assert mocked_blob.upload_from_filename.call_count == 4
+    uploaded_files = [
+        args[0][0].name for args in mocked_blob.upload_from_filename.call_args_list
+    ]
+    assert set(uploaded_files) == {
+        "testfile1.txt",
+        "testfile2.txt",
+        "testfile3.txt",
+        "testfile5.txt",
+    }
+
+
+def test_pull_project_from_gcs(gcs_setup, tmp_path, mock_credentials):
+    mocked_storage_client, mocked_bucket, mocked_blob = gcs_setup
+
+    bucket_name = "my-test-bucket"
+    folder = "my-project"
+
+    files = {
+        f"{folder}/testfile1.txt": "Hello, world!",
+        f"{folder}/testfile2.txt": "Test content",
+        f"{folder}/testdir1/testfile3.txt": "Nested file",
+    }
+
+    class MockBlob:
+        def __init__(self, name):
+            self.name = name
+
+        def download_to_filename(self, local_blob_download_path):
+            for key, content in files.items():
+                if local_blob_download_path == PurePosixPath(
+                    tmp_path
+                    / relative_path_to_current_platform(key).relative_to(folder)
+                ):
+                    Path(local_blob_download_path).write_text(content)
+
+    # Mock the list_blobs method to return the file names in the GCS bucket
+    mocked_storage_client.list_blobs.return_value = [
+        MockBlob(name=key) for key in files.keys()
+    ]
+
+    os.chdir(tmp_path)
+    pull_project_from_gcs(bucket_name, folder)
+
+    for key, content in files.items():
+        target = Path(tmp_path) / PurePosixPath(key).relative_to(folder)
+        assert target.exists()
+        assert target.read_text() == content
+
+
+def test_pull_project_from_gcs_with_service_account_info(
+    gcs_setup, tmp_path, dummy_service_account_info, mock_credentials
+):
+    mocked_storage_client, mocked_bucket, mocked_blob = gcs_setup
+
+    bucket_name = "my-test-bucket"
+    folder = "my-project"
+
+    credentials = {
+        "service_account_info": dummy_service_account_info,
+    }
+
+    os.chdir(tmp_path)
+    pull_project_from_gcs(bucket_name, folder, credentials=credentials)
+
+    mock_credentials.from_service_account_info.assert_called_once_with(
+        dummy_service_account_info,
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+
+
+def test_pull_project_from_gcs_with_service_account_file(
+    gcs_setup, tmp_path, dummy_service_account_file, mock_credentials
+):
+    mocked_storage_client, mocked_bucket, mocked_blob = gcs_setup
+
+    bucket_name = "my-test-bucket"
+    folder = "my-project"
+
+    credentials = {
+        "service_account_file": dummy_service_account_file,
+    }
+
+    os.chdir(tmp_path)
+    pull_project_from_gcs(bucket_name, folder, credentials=credentials)
+
+    mock_credentials.from_service_account_file.assert_called_once_with(
+        dummy_service_account_file,
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+
+
+def test_push_project_to_gcs_with_service_account_info(
+    gcs_setup, tmp_path, dummy_service_account_info, mock_credentials
+):
+    mocked_storage_client, mocked_bucket, mocked_blob = gcs_setup
+
+    bucket_name = "my-test-bucket"
+    folder = "my-project"
+
+    credentials = {
+        "service_account_info": dummy_service_account_info,
+    }
+
+    os.chdir(tmp_path)
+    push_project_to_gcs(bucket_name, folder, credentials=credentials)
+
+    mock_credentials.from_service_account_info.assert_called_once_with(
+        dummy_service_account_info,
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+
+
+def test_push_project_to_gcs_with_service_account_file(
+    gcs_setup, tmp_path, dummy_service_account_file, mock_credentials
+):
+    mocked_storage_client, mocked_bucket, mocked_blob = gcs_setup
+
+    bucket_name = "my-test-bucket"
+    folder = "my-project"
+
+    credentials = {
+        "service_account_file": dummy_service_account_file,
+    }
+
+    os.chdir(tmp_path)
+    push_project_to_gcs(bucket_name, folder, credentials=credentials)
+
+    mock_credentials.from_service_account_file.assert_called_once_with(
+        dummy_service_account_file,
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Adds `push_project_to_gcs` and `pull_project_from_gcs` steps.

Each step accepts a `bucket` and `folder` to upload to/download from along with a `credentials` dictionary. The `credentials` dictionary is set up to match the shape of the data stored in a `GcpCredentials` block document, but using a `GcpCredentials` block is not required.

Closes #160 
Closes #164

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
```yaml
push:
    - prefect_gcp.projects.steps.push_project_to_gcs:
        requires: prefect-gcp>=0.4.0
        bucket: null # Replace with your bucket name
        folder: null # Folder in the bucket where the project will be uploaded

pull:
    - prefect_gcp.projects.steps.pull_project_from_gcs:
        requires: prefect-gcp>=0.4.0
        bucket: null # Replace with your bucket name
        folder: null # Folder in the bucket where the project is stored
```


### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
![Screenshot 2023-04-05 at 7 01 43 AM](https://user-images.githubusercontent.com/12350579/230074509-86ec176b-54db-4e1d-9635-a79b045f661b.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
