### PR TITLE
`CloudRunWorker`

### DIFF
--- a/docs/worker.md
+++ b/docs/worker.md
@@ -1,1 +1,0 @@
-::: prefect_gcp.worker

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -1,0 +1,1 @@
+::: prefect_gcp.worker

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
         - Secret Manager: secret_manager.md
         - Cloud Run: cloud_run.md
         - AI Platform: aiplatform.md
+        - Worker: worker.md
 
 extra:
     social:

--- a/prefect_gcp/__init__.py
+++ b/prefect_gcp/__init__.py
@@ -6,5 +6,6 @@ from .cloud_storage import GcsBucket  # noqa
 from .cloud_run import CloudRunJob  # noqa
 from .secret_manager import GcpSecret  # noqa
 from .credentials import GcpCredentials  # noqa
+from .worker import CloudRunWorker  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import time
 from typing import Any, Dict, List, Optional
@@ -93,7 +95,9 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
     credentials: Optional[GcpCredentials] = Field(
         title="GCP Credentials",
         default_factory=GcpCredentials,
-        description="The GCP Credentials used to connect to Cloud Run. If not provided credentials will be inferred from the local environment.",
+        description="The GCP Credentials used to connect to Cloud Run. "
+        "If not provided credentials will be inferred from "
+        "the local environment.",
     )
     job_body: Dict[str, Any] = Field(template=_get_default_job_body_template())
     timeout: Optional[int] = Field(
@@ -241,14 +245,18 @@ class CloudRunWorkerVariables(BaseVariables):
     credentials: Optional[GcpCredentials] = Field(
         title="GCP Credentials",
         default_factory=GcpCredentials,
-        description="The GCP Credentials used to initiate the Cloud Run Job. If not provided credentials will be inferred from the local environment.",
+        description="The GCP Credentials used to initiate the "
+        "Cloud Run Job. If not provided credentials will be "
+        "inferred from the local environment.",
     )
     image: Optional[str] = Field(
         default=None,
         title="Image Name",
         description=(
-            "The image to use for a new Cloud Run Job. See https://cloud.google.com/run/docs/deploying#images"
-            "for supported image registries. If not set, the latest Prefect image will be used."
+            "The image to use for a new Cloud Run Job. "
+            "See https://cloud.google.com/run/docs/deploying#images"
+            "for supported image registries. "
+            "If not set, the latest Prefect image will be used."
         ),
         example="docker.io/prefecthq/prefect:2-latest",
     )
@@ -262,7 +270,7 @@ class CloudRunWorkerVariables(BaseVariables):
             "1000m = 1 CPU."
         ),
         example="1000m",
-        regex="^(\d*000)m$",
+        regex=r"^(\d*000)m$",
     )
     memory: Optional[str] = Field(
         default=None,
@@ -281,9 +289,10 @@ class CloudRunWorkerVariables(BaseVariables):
     service_account_name: Optional[str] = Field(
         default=None,
         title="Service Account Name",
-        description="The name of the service account to use for the task execution of Cloud Run Job."
-        "By default Cloud Run jobs run as the default Compute Engine Service Account if not specified."
-        "See https://cloud.google.com/run/docs/configuring/service-accounts.",
+        description="The name of the service account to use for the task execution "
+        "of Cloud Run Job. By default Cloud Run jobs run as the default "
+        "Compute Engine Service Account if not specified. See "
+        "https://cloud.google.com/run/docs/configuring/service-accounts.",
     )
     args: Optional[List[str]] = Field(
         default=None,
@@ -417,7 +426,8 @@ class CloudRunWorker(BaseWorker):
             )
             if not configuration.keep_job:
                 self._logger.info(
-                    f"Deleting Cloud Run Job {configuration.job_name} from Google Cloud Run."
+                    f"Deleting Cloud Run Job {configuration.job_name} from "
+                    "Google Cloud Run."
                 )
                 try:
                     Job.delete(
@@ -487,7 +497,8 @@ class CloudRunWorker(BaseWorker):
             status_code = 1
             error_msg = job_execution.condition_after_completion()["message"]
             self._logger.error(
-                f"Job Run {configuration.job_name} did not complete successfully. {error_msg}"
+                "Job Run {configuration.job_name} did not complete successfully. "
+                f"{error_msg}"
             )
 
         self._logger.info(
@@ -496,8 +507,8 @@ class CloudRunWorker(BaseWorker):
 
         if not configuration.keep_job:
             self._logger.info(
-                f"Deleting completed Cloud Run Job {configuration.job_name!r} from Google Cloud"
-                " Run..."
+                f"Deleting completed Cloud Run Job {configuration.job_name!r} "
+                "from Google Cloud Run..."
             )
             try:
                 Job.delete(

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -4,7 +4,7 @@ TODO docstring!
 
 import re
 import time
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import anyio
 import googleapiclient
@@ -25,6 +25,11 @@ from pydantic import Field, validator
 
 from prefect_gcp.cloud_run import Execution, Job
 from prefect_gcp.credentials import GcpCredentials
+
+if TYPE_CHECKING:
+    from prefect.client.schemas import FlowRun
+    from prefect.server.schemas.core import Flow
+    from prefect.server.schemas.responses import DeploymentResponse
 
 
 def _get_default_job_body_template() -> Dict[str, Any]:
@@ -109,6 +114,7 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
         timeout: The length of time that Prefect will wait for a Cloud Run Job.
         keep_job: Whether to delete the Cloud Run Job after it completes.
     """
+
     region: str = Field(..., description="The region where the Cloud Run Job resides.")
     credentials: Optional[GcpCredentials] = Field(
         title="GCP Credentials",
@@ -270,6 +276,7 @@ class CloudRunWorkerVariables(BaseVariables):
     The schema for this class is used to populate the `variables` section of the default
     base job template.
     """
+
     region: str = Field(..., description="The region where the Cloud Run Job resides.")
     credentials: Optional[GcpCredentials] = Field(
         title="GCP Credentials",

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -5,16 +5,17 @@ Module containing the Cloud Run worker used for executing flow runs as Cloud Run
 
 Note this module is in **beta**. The interfaces within may change without notice.
 
-## Starting a Cloud Run worker
-
-To start a Cloud Run worker, run the following command:
+Get started by creating a Cloud Run work pool:
 
 ```bash
-prefect worker start --pool 'my-work-pool' --type cloud-run
+prefect work-pool create 'my-cloud-run-pool' --type cloud-run
 ```
 
-This will automatically create a `cloud-run` work pool named `my-work-pool`.
-You can replace `my-work-pool` with the name of any existing `cloud-run` work pool.
+Then start a Cloud Run worker with the following command:
+
+```bash
+prefect worker start --pool 'my-cloud-run-pool'
+```
 
 ## Configuration
 Read more about configuring work pools

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -1,0 +1,563 @@
+
+from typing import Any, Dict, List, Optional, Literal
+from pydantic import Field
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+import re
+import time
+from prefect.workers.base import BaseWorker, BaseJobConfiguration, BaseVariables, BaseWorkerResult
+import googleapiclient
+from anyio.abc import TaskStatus
+from google.api_core.client_options import ClientOptions
+from googleapiclient import discovery
+from googleapiclient.discovery import Resource
+from prefect.exceptions import InfrastructureNotFound
+from prefect.infrastructure.base import Infrastructure, InfrastructureResult
+from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
+from pydantic import BaseModel, Field, root_validator, validator
+from typing import Dict, Any
+import anyio
+from prefect_gcp.credentials import GcpCredentials
+
+from prefect_gcp.cloud_run import Job, Execution
+from prefect.docker import get_prefect_image_name
+
+
+def _get_default_job_body_template() -> Dict[str, Any]:
+    return {
+        "apiVersion": "run.googleapis.com/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": "{{ name }}",
+            "annotations": {
+            # See: https://cloud.google.com/run/docs/troubleshooting#launch-stage-validation  # noqa
+            "run.googleapis.com/launch-stage": "BETA",
+            }
+        },
+        "spec": {  # JobSpec
+            "template": {  # ExecutionTemplateSpec
+                "spec": {  # ExecutionSpec
+                    "template": {  # TaskTemplateSpec
+                        "spec": {
+                            "containers": [
+                                {
+                                    "image": "{{ image }}",
+                                    "args": "{{ args }}",
+                                }
+                            ],
+                            "timeoutSeconds": "{{ timeout }}",
+                            # "serviceAccountName": "{{ service_account_name }}",
+                        }  # TaskSpec
+                    },
+                },
+            },
+        },
+    }
+
+
+class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
+    region: str = Field(..., description="The region where the Cloud Run Job resides.")
+    credentials: GcpCredentials  # cannot be Field; else it shows as Json
+    job_body: Dict[str, Any] = Field(template=_get_default_job_body_template())
+    timeout: Optional[int] = Field(
+        default=600,
+        gt=0,
+        le=3600,
+        title="Job Timeout",
+        description=(
+            "The length of time that Prefect will wait for a Cloud Run Job to complete "
+            "before raising an exception."
+        ),
+    )
+    keep_job: Optional[bool] = Field(
+        default=False,
+        title="Keep Job After Completion",
+        description="Keep the completed Cloud Run Job on Google Cloud Platform.",
+    )
+
+    # For private use
+    _job_name: str = None
+    _execution: Optional[Execution] = None
+
+    @property
+    def project(self) -> str:
+        return self.credentials.project
+
+    @property
+    def job_name(self) -> str:
+        return self.job_body["metadata"]["name"]
+
+    def prepare_for_flow_run(
+        self,
+        flow_run: "FlowRun",
+        deployment: Optional["DeploymentResponse"] = None,
+        flow: Optional["Flow"] = None,
+    ):
+        """
+        Prepares the job configuration for a flow run.
+
+        Ensures that necessary values are present in the job manifest and that the
+        job manifest is valid.
+
+        Args:
+            flow_run: The flow run to prepare the job configuration for
+            deployment: The deployment associated with the flow run used for
+                preparation.
+            flow: The flow associated with the flow run used for preparation.
+        """
+        super().prepare_for_flow_run(flow_run, deployment, flow)
+        self._populate_envs()
+
+        # set task execution service account to the email of the credentials`
+        self.job_body["spec"]["template"]["spec"]["template"]["spec"]["serviceAccountName"] = self.credentials.client_email
+
+        self._populate_image_if_not_present()
+        self._populate_command_if_not_present()
+        self._populate_name_if_not_present()
+
+    def _populate_envs(self):
+        envs = [{"name": k, "value": v} for k, v in self.env.items()]
+        self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["env"] = envs
+
+    def _populate_name_if_not_present(self):
+        try:
+            if "name" not in self.job_body["metadata"]:
+                self.job_body["metadata"]["name"] = f"prefect-job-{uuid4()}"
+        except KeyError:
+            raise ValueError(
+                "Unable to verify name due to invalid job body template."
+            )
+
+    def _populate_image_if_not_present(self):
+        try:
+            if (
+                "image"
+                not in self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]
+            ):
+                self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0][
+                    "image"
+                ] = f"docker.io/{get_prefect_image_name()}"
+        except KeyError:
+            raise ValueError(
+                "Unable to verify image due to invalid job body template."
+            )
+
+    def _populate_command_if_not_present(self):
+        """
+        Ensures that the command is present in the job manifest. Populates the command
+        with the `prefect -m prefect.engine` if a command is not present.
+        """
+        try:
+            command = self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0].get("args")
+            if command is None:
+                self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["args"] = [
+                    "python",
+                    "-m",
+                    "prefect.engine",
+                ]
+            elif isinstance(command, str):
+                self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["args"] = command.split()
+            elif not isinstance(command, list):
+                raise ValueError(
+                    "Invalid job manifest template: 'command' must be a string or list."
+                )
+        except KeyError:
+            raise ValueError(
+                "Unable to verify command due to invalid job manifest template."
+            )
+
+    def _add_args(self) -> dict:
+        """Set the arguments that will be passed to the entrypoint for a Cloud Run Job.
+        See: https://cloud.google.com/run/docs/reference/rest/v1/Container
+        """  # noqa
+        return {"args": self.args} if self.args else {}
+
+    def _add_command(self) -> dict:
+        """Set the command that a container will run for a Cloud Run Job.
+        See: https://cloud.google.com/run/docs/reference/rest/v1/Container
+        """  # noqa
+        return {"command": self.command}
+
+    def _add_resources(self) -> dict:
+        """Set specified resources limits for a Cloud Run Job.
+        See: https://cloud.google.com/run/docs/reference/rest/v1/Container#ResourceRequirements
+        See also: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """  # noqa
+        resources = {"limits": {}, "requests": {}}
+
+        if self.cpu is not None:
+            cpu = self._cpu_as_k8s_quantity()
+            resources["limits"]["cpu"] = cpu
+            resources["requests"]["cpu"] = cpu
+        if self.memory_string is not None:
+            resources["limits"]["memory"] = self.memory_string
+            resources["requests"]["memory"] = self.memory_string
+
+        return {"resources": resources} if resources["requests"] else {}
+
+    def _add_env(self) -> dict:
+        """Add environment variables for a Cloud Run Job.
+
+        Method `self._base_environment()` gets necessary Prefect environment variables
+        from the config.
+
+        See: https://cloud.google.com/run/docs/reference/rest/v1/Container#envvar for
+        how environment variables are specified for Cloud Run Jobs.
+        """  # noqa
+        env = {**self._base_environment(), **self.env}
+        cloud_run_env = [{"name": k, "value": v} for k, v in env.items()]
+        return {"env": cloud_run_env}
+
+
+class CloudRunWorkerVariables(BaseVariables):
+    image: Optional[str] = Field(
+        default=None,
+        title="Image Name",
+        description=(
+            "The full image to use for a new Cloud Run Job. See https://cloud.google.com/run/docs/deploying#images"
+            "for supported image registries. If not set, the latest Prefect image will be used."
+        ),
+        example="docker.io/prefecthq/prefect:2-latest",
+    )
+    region: str = Field(..., description="The region where the Cloud Run Job resides.")
+    credentials: GcpCredentials  # cannot be Field; else it shows as Json
+
+    # Job settings
+    cpu: Optional[int] = Field(
+        default=None,
+        title="CPU",
+        description=(
+            "The amount of compute allocated to the Cloud Run Job. "
+            "The int must be valid based on the rules specified at "
+            "https://cloud.google.com/run/docs/configuring/cpu#setting-jobs ."
+        ),
+    )
+    memory: Optional[int] = Field(
+        default=None,
+        title="Memory",
+        description="The amount of memory allocated to the Cloud Run Job.",
+    )
+    memory_unit: Optional[Literal["G", "Gi", "M", "Mi"]] = Field(
+        default=None,
+        title="Memory Units",
+        description=(
+            "The unit of memory. See "
+            "https://cloud.google.com/run/docs/configuring/memory-limits#setting "
+            "for additional details."
+        ),
+    )
+    vpc_connector_name: Optional[str] = Field(
+        default=None,
+        title="VPC Connector Name",
+        description="The name of the VPC connector to use for the Cloud Run Job.",
+    )
+    args: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Arguments to be passed to your Cloud Run Job's entrypoint command."
+        ),
+    )
+    keep_job: Optional[bool] = Field(
+        default=False,
+        title="Keep Job After Completion",
+        description="Keep the completed Cloud Run Job on Google Cloud Platform.",
+    )
+    timeout: Optional[int] = Field(
+        default=600,
+        gt=0,
+        le=3600,
+        title="Job Timeout",
+        description=(
+            "The length of time that Prefect will wait for a Cloud Run Job to complete "
+            "before raising an exception."
+        ),
+    )
+
+
+class CloudRunWorkerResult(BaseWorkerResult):
+    """Contains information about the final state of a completed process"""
+
+
+class CloudRunWorker(BaseWorker):
+    type = "cloud-run"
+    job_configuration = CloudRunWorkerJobConfiguration
+    job_configuration_variables = CloudRunWorkerVariables
+
+    async def _check_flow_run(self, flow_run: "FlowRun") -> None:
+        pass
+
+    @property
+    def memory_string(self):
+        """Returns the string expected for memory resources argument."""
+        if self.memory and self.memory_unit:
+            return str(self.memory) + self.memory_unit
+        return None
+
+    @validator("image")
+    def _remove_image_spaces(cls, value):
+        """Deal with spaces in image names."""
+        if value is not None:
+            return value.strip()
+
+    @root_validator
+    def _check_valid_memory(cls, values):
+        """Make sure memory conforms to expected values for API.
+        See: https://cloud.google.com/run/docs/configuring/memory-limits#setting
+        """  # noqa
+        if (values.get("memory") is not None and values.get("memory_unit") is None) or (
+            values.get("memory_unit") is not None and values.get("memory") is None
+        ):
+            raise ValueError(
+                "A memory value and unit must both be supplied to specify a memory"
+                " value other than the default memory value."
+            )
+        return values
+
+    def _create_job_error(self, exc, configuration):
+        """Provides a nicer error for 404s when trying to create a Cloud Run Job."""
+        # TODO consider lookup table instead of the if/else,
+        # also check for documented errors
+        if exc.status_code == 404:
+            raise RuntimeError(
+                f"Failed to find resources at {exc.uri}. Confirm that region"
+                f" '{self.region}' is the correct region for your Cloud Run Job and"
+                f" that {configuration.project} is the correct GCP project. If"
+                f" your project ID is not correct, you are using a Credentials block"
+                f" with permissions for the wrong project."
+            ) from exc
+        raise exc
+
+    def _job_run_submission_error(self, exc, configuration):
+        """Provides a nicer error for 404s when submitting job runs."""
+        if exc.status_code == 404:
+            pat1 = r"The requested URL [^ ]+ was not found on this server"
+            # pat2 = (
+            #     r"Resource '[^ ]+' of kind 'JOB' in region '[\w\-0-9]+' "
+            #     r"in project '[\w\-0-9]+' does not exist"
+            # )
+            if re.findall(pat1, str(exc)):
+                raise RuntimeError(
+                    f"Failed to find resources at {exc.uri}. "
+                    f"Confirm that region '{self.region}' is "
+                    f"the correct region for your Cloud Run Job "
+                    f"and that '{configuration.project}' is the "
+                    f"correct GCP project. If your project ID is not "
+                    f"correct, you are using a Credentials "
+                    f"block with permissions for the wrong project."
+                ) from exc
+            else:
+                raise exc
+
+        raise exc
+
+    def _cpu_as_k8s_quantity(self) -> str:
+        """Return the CPU integer in the format expected by GCP Cloud Run Jobs API.
+        See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        See also: https://cloud.google.com/run/docs/configuring/cpu#setting-jobs
+        """  # noqa
+        return str(self.cpu * 1000) + "m"
+
+    @sync_compatible
+    async def run(
+        self,
+        flow_run: "FlowRun",
+        configuration: CloudRunWorkerJobConfiguration,
+        task_status: Optional[anyio.abc.TaskStatus] = None,
+    ) -> BaseWorkerResult:
+
+        with self._get_client(configuration) as client:
+            await run_sync_in_worker_thread(
+                self._create_job_and_wait_for_registration, configuration, client
+            )
+            job_execution = await run_sync_in_worker_thread(
+                self._begin_job_execution, configuration, client
+            )
+
+            if task_status:
+                task_status.started(configuration.job_name)
+
+            result = await run_sync_in_worker_thread(
+                self._watch_job_execution_and_get_result,
+                configuration,
+                client,
+                job_execution,
+            )
+            return result
+
+    def _get_client(self, configuration: CloudRunWorkerJobConfiguration) -> Resource:
+        """Get the base client needed for interacting with GCP APIs."""
+        # region needed for 'v1' API
+        api_endpoint = f"https://{configuration.region}-run.googleapis.com"
+        gcp_creds = configuration.credentials.get_credentials_from_service_account()
+        options = ClientOptions(api_endpoint=api_endpoint)
+
+        return discovery.build(
+            "run", "v1", client_options=options, credentials=gcp_creds
+        ).namespaces()
+
+    def _create_job_and_wait_for_registration(self, configuration: CloudRunWorkerJobConfiguration, client: Resource) -> None:
+        """Create a new job wait for it to finish registering."""
+        try:
+            self._logger.info(f"Creating Cloud Run Job {configuration.job_name}")
+
+            Job.create(
+                client=client,
+                namespace=configuration.credentials.project,
+                body=configuration.job_body,
+            )
+        except googleapiclient.errors.HttpError as exc:
+            self._create_job_error(exc, configuration)
+
+        try:
+            self._wait_for_job_creation(client=client, configuration=configuration)
+        except Exception:
+            self._logger.exception(
+                "Encountered an exception while waiting for job run creation"
+            )
+            if not configuration.keep_job:
+                self._logger.info(
+                    f"Deleting Cloud Run Job {configuration.job_name} from Google Cloud Run."
+                )
+                try:
+                    Job.delete(
+                        client=client,
+                        namespace=configuration.credentials.project,
+                        job_name=configuration.job_name,
+                    )
+                except Exception:
+                    self._logger.exception(
+                        "Received an unexpected exception while attempting to delete"
+                        f" Cloud Run Job {configuration.job_name!r}"
+                    )
+            raise
+
+    def _begin_job_execution(self, configuration: CloudRunWorkerJobConfiguration, client: Resource) -> Execution:
+        """Submit a job run for execution and return the execution object."""
+        try:
+            self._logger.info(
+                f"Submitting Cloud Run Job {configuration.job_name!r} for execution."
+            )
+            submission = Job.run(
+                client=client,
+                namespace=configuration.project,
+                job_name=configuration.job_name,
+            )
+
+            job_execution = Execution.get(
+                client=client,
+                namespace=submission["metadata"]["namespace"],
+                execution_name=submission["metadata"]["name"],
+            )
+        except Exception as exc:
+            self._job_run_submission_error(exc, configuration)
+
+        return job_execution
+
+    def _watch_job_execution_and_get_result(
+        self, configuration: CloudRunWorkerJobConfiguration, client: Resource, execution: Execution, poll_interval: int=5
+    ) -> CloudRunWorkerResult:
+        """Wait for execution to complete and then return result."""
+        try:
+            job_execution = self._watch_job_execution(
+                client=client,
+                job_execution=execution,
+                timeout=configuration.timeout,
+                poll_interval=poll_interval,
+            )
+        except Exception:
+            self._logger.exception(
+                "Received an unexpected exception while monitoring Cloud Run Job "
+                f"{configuration.job_name!r}"
+            )
+            raise
+
+        if job_execution.succeeded():
+            status_code = 0
+            self._logger.info(f"Job Run {configuration.job_name} completed successfully")
+        else:
+            status_code = 1
+            error_msg = job_execution.condition_after_completion()["message"]
+            self._logger.error(
+                f"Job Run {configuration.job_name} did not complete successfully. {error_msg}"
+            )
+
+        self._logger.info(
+            f"Job Run logs can be found on GCP at: {job_execution.log_uri}"
+        )
+
+        if not configuration.keep_job:
+            self._logger.info(
+                f"Deleting completed Cloud Run Job {configuration.job_name!r} from Google Cloud"
+                " Run..."
+            )
+            try:
+                Job.delete(
+                    client=client,
+                    namespace=configuration.project,
+                    job_name=configuration.job_name,
+                )
+            except Exception:
+                self._logger.exception(
+                    "Received an unexpected exception while attempting to delete Cloud"
+                    f" Run Job {configuration.job_name}"
+                )
+
+        return CloudRunWorkerResult(identifier=configuration.job_name, status_code=status_code)
+
+    def _watch_job_execution(
+        self, client, job_execution: Execution, timeout: int, poll_interval: int = 5
+    ):
+        """
+        Update job_execution status until it is no longer running or timeout is reached.
+        """
+        t0 = time.time()
+        while job_execution.is_running():
+            job_execution = Execution.get(
+                client=client,
+                namespace=job_execution.namespace,
+                execution_name=job_execution.name,
+            )
+
+            elapsed_time = time.time() - t0
+            if timeout is not None and elapsed_time > timeout:
+                raise RuntimeError(
+                    f"Timed out after {elapsed_time}s while waiting for Cloud Run Job "
+                    "execution to complete. Your job may still be running on GCP."
+                )
+
+            time.sleep(poll_interval)
+
+        return job_execution
+
+    def _wait_for_job_creation(
+        self, client: Resource, configuration: CloudRunWorkerJobConfiguration, poll_interval: int = 5
+    ):
+        """Give created job time to register."""
+        job = Job.get(
+            client=client, namespace=configuration.project, job_name=configuration.job_name
+        )
+
+        t0 = time.time()
+        while not job.is_ready():
+            ready_condition = (
+                job.ready_condition
+                if job.ready_condition
+                else "waiting for condition update"
+            )
+            self._logger.info(
+                f"Job is not yet ready... Current condition: {ready_condition}"
+            )
+            job = Job.get(
+                client=client,
+                namespace=configuration.project,
+                job_name=configuration.job_name,
+            )
+
+            elapsed_time = time.time() - t0
+            if configuration.timeout is not None and elapsed_time > configuration.timeout:
+                raise RuntimeError(
+                    f"Timed out after {elapsed_time}s while waiting for Cloud Run Job "
+                    "execution to complete. Your job may still be running on GCP."
+                )
+
+            time.sleep(poll_interval)

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -277,7 +277,11 @@ class CloudRunWorkerVariables(BaseVariables):
     base job template.
     """
 
-    region: str = Field(..., description="The region where the Cloud Run Job resides.")
+    region: str = Field(
+        ...,
+        description="The region where the Cloud Run Job resides.",
+        example="us-central1",
+    )
     credentials: Optional[GcpCredentials] = Field(
         title="GCP Credentials",
         default_factory=GcpCredentials,
@@ -290,9 +294,8 @@ class CloudRunWorkerVariables(BaseVariables):
         title="Image Name",
         description=(
             "The image to use for a new Cloud Run Job. "
-            "See https://cloud.google.com/run/docs/deploying#images"
-            "for supported image registries. "
-            "If not set, the latest Prefect image will be used."
+            "If not set, the latest Prefect image will be used. "
+            "See https://cloud.google.com/run/docs/deploying#images."
         ),
         example="docker.io/prefecthq/prefect:2-latest",
     )
@@ -301,9 +304,8 @@ class CloudRunWorkerVariables(BaseVariables):
         title="CPU",
         description=(
             "The amount of compute allocated to the Cloud Run Job. "
-            "The int must be valid based on the rules specified at "
+            "(1000m = 1 CPU). See "
             "https://cloud.google.com/run/docs/configuring/cpu#setting-jobs."
-            "1000m = 1 CPU."
         ),
         example="1000m",
         regex=r"^(\d*000)m$",
@@ -311,9 +313,11 @@ class CloudRunWorkerVariables(BaseVariables):
     memory: Optional[str] = Field(
         default=None,
         title="Memory",
-        description="The amount of memory allocated to the Cloud Run Job. See"
-        "https://cloud.google.com/run/docs/configuring/memory-limits#setting "
-        "for additional details. Must end in 'G', 'Gi', 'M', or 'Mi'.",
+        description=(
+            "The amount of memory allocated to the Cloud Run Job. "
+            "Must be specified in units of 'G', 'Gi', 'M', or 'Mi'. "
+            "See https://cloud.google.com/run/docs/configuring/memory-limits#setting."
+        ),
         example="512Mi",
         regex=r"^\d+(?:G|Gi|M|Mi)$",
     )
@@ -327,8 +331,8 @@ class CloudRunWorkerVariables(BaseVariables):
         title="Service Account Name",
         description="The name of the service account to use for the task execution "
         "of Cloud Run Job. By default Cloud Run jobs run as the default "
-        "Compute Engine Service Account if not specified. See "
-        "https://cloud.google.com/run/docs/configuring/service-accounts.",
+        "Compute Engine Service Account. ",
+        example="service-account@example.iam.gserviceaccount.com",
     )
     args: Optional[List[str]] = Field(
         default=None,
@@ -339,7 +343,7 @@ class CloudRunWorkerVariables(BaseVariables):
     keep_job: Optional[bool] = Field(
         default=False,
         title="Keep Job After Completion",
-        description="Keep the completed Cloud Run Job on Google Cloud Platform.",
+        description="Keep the completed Cloud Run Job after it has run.",
     )
     timeout: Optional[int] = Field(
         default=600,

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -1,6 +1,6 @@
 import re
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
 import anyio
@@ -17,7 +17,7 @@ from prefect.workers.base import (
     BaseWorker,
     BaseWorkerResult,
 )
-from pydantic import Field
+from pydantic import Field, validator
 
 from prefect_gcp.cloud_run import Execution, Job
 from prefect_gcp.credentials import GcpCredentials
@@ -32,23 +32,33 @@ def _get_default_job_body_template() -> Dict[str, Any]:
             "annotations": {
                 # See: https://cloud.google.com/run/docs/troubleshooting#launch-stage-validation  # noqa
                 "run.googleapis.com/launch-stage": "BETA",
+                "run.googleapis.com/vpc-access-connector": "{{ vpc_connector_name }}"
             },
         },
         "spec": {  # JobSpec
             "template": {  # ExecutionTemplateSpec
                 "spec": {  # ExecutionSpec
                     "template": {  # TaskTemplateSpec
-                        "spec": {
+                        "spec": {  # TaskSpec
                             "containers": [
                                 {
                                     "image": "{{ image }}",
                                     "args": "{{ args }}",
+                                    "resources": {
+                                        "limits": {
+                                            "cpu": "{{ cpu }}",
+                                            "memory": "{{ memory }}",
+                                        },
+                                        "requests": {
+                                            "cpu": "{{ cpu }}",
+                                            "memory": "{{ memory }}",
+                                        }
+                                    }
                                 }
                             ],
                             "timeoutSeconds": "{{ timeout }}",
-                            # TODO what to do about this?
-                            # "serviceAccountName": "{{ service_account_name }}",
-                        }  # TaskSpec
+                            "serviceAccountName": "{{ service_account_name }}",
+                        }
                     },
                 },
             },
@@ -75,10 +85,6 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
         title="Keep Job After Completion",
         description="Keep the completed Cloud Run Job on Google Cloud Platform.",
     )
-
-    # For private use
-    _job_name: str = None
-    _execution: Optional[Execution] = None
 
     @property
     def project(self) -> str:
@@ -108,22 +114,36 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
         """
         super().prepare_for_flow_run(flow_run, deployment, flow)
         self._populate_envs()
-
-        # TODO what to do about this?
-        # set task execution service account to the email of the credentials`
-        self.job_body["spec"]["template"]["spec"]["template"]["spec"]["serviceAccountName"] = self.credentials.client_email
-
+        self._populate_service_account_if_not_present()
         self._populate_image_if_not_present()
         self._populate_command_if_not_present()
         self._populate_name_if_not_present()
 
+    def _populate_service_account_if_not_present(self):
+        """Populate the service account used for Cloud Run Job Execution if not provided.
+        The service account will be the one from `credentials`."""
+
+        try:
+            if "serviceAccountName" not in self.job_body["spec"]["template"]["spec"]["template"]["spec"]:
+                self.job_body["spec"]["template"]["spec"]["template"]["spec"][
+                    "serviceAccountName"
+                ] = self.credentials.client_email
+        except KeyError:
+            raise ValueError(
+                "Unable to verify service account due to invalid job body template."
+            )
+
     def _populate_envs(self):
+        """Populate environment variables. BaseWorker.prepare_for_flow_run handles
+        putting the environment variables in the `env` attribute. This method
+        moves them into the jobs body"""
         envs = [{"name": k, "value": v} for k, v in self.env.items()]
         self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0][
             "env"
         ] = envs
 
     def _populate_name_if_not_present(self):
+        # TODO should we give this a flow run id?
         try:
             if "name" not in self.job_body["metadata"]:
                 self.job_body["metadata"]["name"] = f"prefect-job-{uuid4()}"
@@ -187,6 +207,32 @@ class CloudRunWorkerVariables(BaseVariables):
         ),
         example="docker.io/prefecthq/prefect:2-latest",
     )
+    cpu: Optional[str] = Field(
+        default=None,
+        title="CPU",
+        description=(
+            "The amount of compute allocated to the Cloud Run Job. "
+            "The int must be valid based on the rules specified at "
+            "https://cloud.google.com/run/docs/configuring/cpu#setting-jobs."
+            "1000m = 1 CPU."
+        ),
+        example="1000m",
+        regex="^(\d*000)m$"
+    )
+    memory: Optional[str] = Field(
+        default=None,
+        title="Memory",
+        description="The amount of memory allocated to the Cloud Run Job. See"
+                    "https://cloud.google.com/run/docs/configuring/memory-limits#setting "
+                    "for additional details. Must end in 'G', 'Gi', 'M', or 'Mi'.",
+        example="512Mi",
+        regex=r'^\d+(?:G|Gi|M|Mi)$'
+    )
+    vpc_connector_name: Optional[str] = Field(
+        default=None,
+        title="VPC Connector Name",
+        description="The name of the VPC connector to use for the Cloud Run Job.",
+    )
     args: Optional[List[str]] = Field(
         default=None,
         description=(
@@ -209,7 +255,6 @@ class CloudRunWorkerVariables(BaseVariables):
         ),
     )
 
-
 class CloudRunWorkerResult(BaseWorkerResult):
     """Contains information about the final state of a completed process"""
 
@@ -219,9 +264,9 @@ class CloudRunWorker(BaseWorker):
     job_configuration = CloudRunWorkerJobConfiguration
     job_configuration_variables = CloudRunWorkerVariables
 
-    # TODO: remove
-    # async def _check_flow_run(self, flow_run: "FlowRun") -> None:
-    #     pass
+    # TODO: remove! this is only to use remote storage for testing convience
+    async def _check_flow_run(self, flow_run: "FlowRun") -> None:
+        pass
 
     def _create_job_error(self, exc, configuration):
         """Provides a nicer error for 404s when trying to create a Cloud Run Job."""
@@ -303,7 +348,8 @@ class CloudRunWorker(BaseWorker):
         """Create a new job wait for it to finish registering."""
         try:
             self._logger.info(f"Creating Cloud Run Job {configuration.job_name}")
-
+            import pprint
+            pprint.pprint(configuration.job_body)
             Job.create(
                 client=client,
                 namespace=configuration.credentials.project,

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -34,59 +34,59 @@ pool basis or do so on a per-deployment basis via the `infra_overrides` field.
 !!! example "Using a custom Cloud Run job template"
     The default template used for Cloud Run jobs looks like this:
     ```json
+{
+    "apiVersion": "run.googleapis.com/v1",
+    "kind": "Job",
+    "metadata":
         {
-            "apiVersion": "run.googleapis.com/v1",
-            "kind": "Job",
-            "metadata":
+            "name": "{{ name }}",
+            "annotations":
             {
-                "name": "{{ name }}",
-                "annotations":
-                {
-                    "run.googleapis.com/launch-stage": "BETA",
-                    "run.googleapis.com/vpc-access-connector": "{{ vpc_connector_name }}"
-                }
-            },
-            "spec":
+                "run.googleapis.com/launch-stage": "BETA",
+                "run.googleapis.com/vpc-access-connector": "{{ vpc_connector_name }}"
+            }
+        },
+        "spec":
+        {
+            "template":
             {
-                "template":
+                "spec":
                 {
-                    "spec":
+                    "template":
                     {
-                        "template":
+                        "spec":
                         {
-                            "spec":
-                            {
-                                "containers":
-                                [
+                            "containers":
+                            [
+                                {
+                                    "image": "{{ image }}",
+                                    "args": "{{ args }}",
+                                    "resources":
                                     {
-                                        "image": "{{ image }}",
-                                        "args": "{{ args }}",
-                                        "resources":
+                                        "limits":
                                         {
-                                            "limits":
-                                            {
-                                                "cpu": "{{ cpu }}",
-                                                "memory": "{{ memory }}"
-                                            },
-                                            "requests":
-                                            {
-                                                "cpu": "{{ cpu }}",
-                                                "memory": "{{ memory }}"
-                                            }
+                                            "cpu": "{{ cpu }}",
+                                            "memory": "{{ memory }}"
+                                        },
+                                        "requests":
+                                        {
+                                            "cpu": "{{ cpu }}",
+                                            "memory": "{{ memory }}"
                                         }
                                     }
-                                ],
-                                "timeoutSeconds": "{{ timeout }}",
-                                "serviceAccountName": "{{ service_account_name }}"
-                            }
+                                }
+                            ],
+                            "timeoutSeconds": "{{ timeout }}",
+                            "serviceAccountName": "{{ service_account_name }}"
                         }
                     }
                 }
+                }
             }
-        },
-        "timeout": "{{ timeout }}",
-        "keep_job": "{{ keep_job }}"
-    }
+    },
+    "timeout": "{{ timeout }}",
+    "keep_job": "{{ keep_job }}"
+}
     ```
 
     Each values enclosed in `{{ }}` is a placeholder that will be replaced with
@@ -101,24 +101,24 @@ pool basis or do so on a per-deployment basis via the `infra_overrides` field.
     the default job template, you can add the following
 
     ```json
+{
+    "apiVersion": "run.googleapis.com/v1",
+    "kind": "Job",
+    "metadata":
+    {
+        "name": "{{ name }}",
+        "annotations":
         {
-            "apiVersion": "run.googleapis.com/v1",
-            "kind": "Job",
-            "metadata":
-            {
-                "name": "{{ name }}",
-                "annotations":
-                {
-                    "run.googleapis.com/my-custom-annotation": "{{ my_custom_annotation }}",
-                    "run.googleapis.com/launch-stage": "BETA",
-                    "run.googleapis.com/vpc-access-connector": "{{ vpc_connector_name }}"
-                }
-              ...
-            },
-          ...
-        },
-        ...
-    }
+            "run.googleapis.com/my-custom-annotation": "{{ my_custom_annotation }}",
+            "run.googleapis.com/launch-stage": "BETA",
+            "run.googleapis.com/vpc-access-connector": "{{ vpc_connector_name }}"
+        }
+      ...
+    },
+  ...
+},
+...
+}
     ```
     my-custom-annotation can now be used as a placeholder in the job template and set
     via infra_overrides.
@@ -127,28 +127,28 @@ pool basis or do so on a per-deployment basis via the `infra_overrides` field.
     infra_overrides: {region: "us-central1", "my_custom_annotation": "my-custom-value"}
     ```
 
-    Additionally, you can hardcode fields to prevent configuration at the deployment level.
-    For example to configure the `vpc_connector_name` field, you can remove the templated
-    value and replace it with a hardcoded value.
+    Additionally, you can hardcode fields to prevent configuration at the deployment
+    level.For example to configure the `vpc_connector_name` field, you can remove
+    the templated value and replace it with a hardcoded value.
 
-        ```json
+    ```json
+{
+    "apiVersion": "run.googleapis.com/v1",
+    "kind": "Job",
+    "metadata":
         {
-            "apiVersion": "run.googleapis.com/v1",
-            "kind": "Job",
-            "metadata":
+            "name": "{{ name }}",
+            "annotations":
             {
-                "name": "{{ name }}",
-                "annotations":
-                {
-                    "run.googleapis.com/launch-stage": "BETA",
-                    "run.googleapis.com/vpc-access-connector": "my-hardcoded-vpc-connector"
-                }
-              ...
-            },
+                "run.googleapis.com/launch-stage": "BETA",
+                "run.googleapis.com/vpc-access-connector": "my-hardcoded-vpc-connector"
+            }
           ...
         },
-        ...
-    }
+      ...
+    },
+  ...
+}
     ```
 """
 

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -54,7 +54,6 @@ def _get_default_job_body_template() -> Dict[str, Any]:
                                 {
                                     "image": "{{ image }}",
                                     "command": "{{ command }}",
-                                    "args": "{{ args }}",
                                     "resources": {
                                         "limits": {
                                             "cpu": "{{ cpu }}",
@@ -240,7 +239,7 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
             args = self.job_body["spec"]["template"]["spec"]["template"]["spec"][
                 "containers"
             ][0].get("args")
-            if args is not None:
+            if args is not None and isinstance(args, str):
                 self.job_body["spec"]["template"]["spec"]["template"]["spec"][
                     "containers"
                 ][0]["args"] = shlex.split(args)
@@ -292,13 +291,6 @@ class CloudRunWorkerVariables(BaseVariables):
         ...,
         description="The region where the Cloud Run Job resides.",
         example="us-central1",
-    )
-    args: Optional[str] = Field(
-        default=None,
-        description=(
-            "Arguments to be passed to your Cloud Run Job's entrypoint command. "
-            "Leave blank if using a prefect image."
-        ),
     )
     credentials: Optional[GcpCredentials] = Field(
         title="GCP Credentials",

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -1,8 +1,8 @@
 """
 TODO docstring!
 """
-import shlex
 import re
+import shlex
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -451,9 +451,6 @@ class CloudRunWorker(BaseWorker):
         """Create a new job wait for it to finish registering."""
         try:
             self._logger.info(f"Creating Cloud Run Job {configuration.job_name}")
-            import pprint
-
-            pprint.pprint(configuration.job_body)
 
             Job.create(
                 client=client,

--- a/prefect_gcp/worker.py
+++ b/prefect_gcp/worker.py
@@ -1,26 +1,26 @@
-
-from typing import Any, Dict, List, Optional, Literal
-from pydantic import Field
-from typing import Any, Dict, List, Optional
-from uuid import uuid4
 import re
 import time
-from prefect.workers.base import BaseWorker, BaseJobConfiguration, BaseVariables, BaseWorkerResult
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+import anyio
 import googleapiclient
 from anyio.abc import TaskStatus
 from google.api_core.client_options import ClientOptions
 from googleapiclient import discovery
 from googleapiclient.discovery import Resource
-from prefect.exceptions import InfrastructureNotFound
-from prefect.infrastructure.base import Infrastructure, InfrastructureResult
-from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
-from pydantic import BaseModel, Field, root_validator, validator
-from typing import Dict, Any
-import anyio
-from prefect_gcp.credentials import GcpCredentials
-
-from prefect_gcp.cloud_run import Job, Execution
 from prefect.docker import get_prefect_image_name
+from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
+from prefect.workers.base import (
+    BaseJobConfiguration,
+    BaseVariables,
+    BaseWorker,
+    BaseWorkerResult,
+)
+from pydantic import Field
+
+from prefect_gcp.cloud_run import Execution, Job
+from prefect_gcp.credentials import GcpCredentials
 
 
 def _get_default_job_body_template() -> Dict[str, Any]:
@@ -30,9 +30,9 @@ def _get_default_job_body_template() -> Dict[str, Any]:
         "metadata": {
             "name": "{{ name }}",
             "annotations": {
-            # See: https://cloud.google.com/run/docs/troubleshooting#launch-stage-validation  # noqa
-            "run.googleapis.com/launch-stage": "BETA",
-            }
+                # See: https://cloud.google.com/run/docs/troubleshooting#launch-stage-validation  # noqa
+                "run.googleapis.com/launch-stage": "BETA",
+            },
         },
         "spec": {  # JobSpec
             "template": {  # ExecutionTemplateSpec
@@ -46,6 +46,7 @@ def _get_default_job_body_template() -> Dict[str, Any]:
                                 }
                             ],
                             "timeoutSeconds": "{{ timeout }}",
+                            # TODO what to do about this?
                             # "serviceAccountName": "{{ service_account_name }}",
                         }  # TaskSpec
                     },
@@ -96,8 +97,8 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
         """
         Prepares the job configuration for a flow run.
 
-        Ensures that necessary values are present in the job manifest and that the
-        job manifest is valid.
+        Ensures that necessary values are present in the job body and that the
+        job body is valid.
 
         Args:
             flow_run: The flow run to prepare the job configuration for
@@ -108,6 +109,7 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
         super().prepare_for_flow_run(flow_run, deployment, flow)
         self._populate_envs()
 
+        # TODO what to do about this?
         # set task execution service account to the email of the credentials`
         self.job_body["spec"]["template"]["spec"]["template"]["spec"]["serviceAccountName"] = self.credentials.client_email
 
@@ -117,30 +119,30 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
 
     def _populate_envs(self):
         envs = [{"name": k, "value": v} for k, v in self.env.items()]
-        self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["env"] = envs
+        self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0][
+            "env"
+        ] = envs
 
     def _populate_name_if_not_present(self):
         try:
             if "name" not in self.job_body["metadata"]:
                 self.job_body["metadata"]["name"] = f"prefect-job-{uuid4()}"
         except KeyError:
-            raise ValueError(
-                "Unable to verify name due to invalid job body template."
-            )
+            raise ValueError("Unable to verify name due to invalid job body template.")
 
     def _populate_image_if_not_present(self):
         try:
             if (
                 "image"
-                not in self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]
+                not in self.job_body["spec"]["template"]["spec"]["template"]["spec"][
+                    "containers"
+                ][0]
             ):
-                self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0][
-                    "image"
-                ] = f"docker.io/{get_prefect_image_name()}"
+                self.job_body["spec"]["template"]["spec"]["template"]["spec"][
+                    "containers"
+                ][0]["image"] = f"docker.io/{get_prefect_image_name()}"
         except KeyError:
-            raise ValueError(
-                "Unable to verify image due to invalid job body template."
-            )
+            raise ValueError("Unable to verify image due to invalid job body template.")
 
     def _populate_command_if_not_present(self):
         """
@@ -148,15 +150,21 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
         with the `prefect -m prefect.engine` if a command is not present.
         """
         try:
-            command = self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0].get("args")
+            command = self.job_body["spec"]["template"]["spec"]["template"]["spec"][
+                "containers"
+            ][0].get("args")
             if command is None:
-                self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["args"] = [
+                self.job_body["spec"]["template"]["spec"]["template"]["spec"][
+                    "containers"
+                ][0]["args"] = [
                     "python",
                     "-m",
                     "prefect.engine",
                 ]
             elif isinstance(command, str):
-                self.job_body["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["args"] = command.split()
+                self.job_body["spec"]["template"]["spec"]["template"]["spec"][
+                    "containers"
+                ][0]["args"] = command.split()
             elif not isinstance(command, list):
                 raise ValueError(
                     "Invalid job manifest template: 'command' must be a string or list."
@@ -166,50 +174,10 @@ class CloudRunWorkerJobConfiguration(BaseJobConfiguration):
                 "Unable to verify command due to invalid job manifest template."
             )
 
-    def _add_args(self) -> dict:
-        """Set the arguments that will be passed to the entrypoint for a Cloud Run Job.
-        See: https://cloud.google.com/run/docs/reference/rest/v1/Container
-        """  # noqa
-        return {"args": self.args} if self.args else {}
-
-    def _add_command(self) -> dict:
-        """Set the command that a container will run for a Cloud Run Job.
-        See: https://cloud.google.com/run/docs/reference/rest/v1/Container
-        """  # noqa
-        return {"command": self.command}
-
-    def _add_resources(self) -> dict:
-        """Set specified resources limits for a Cloud Run Job.
-        See: https://cloud.google.com/run/docs/reference/rest/v1/Container#ResourceRequirements
-        See also: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        """  # noqa
-        resources = {"limits": {}, "requests": {}}
-
-        if self.cpu is not None:
-            cpu = self._cpu_as_k8s_quantity()
-            resources["limits"]["cpu"] = cpu
-            resources["requests"]["cpu"] = cpu
-        if self.memory_string is not None:
-            resources["limits"]["memory"] = self.memory_string
-            resources["requests"]["memory"] = self.memory_string
-
-        return {"resources": resources} if resources["requests"] else {}
-
-    def _add_env(self) -> dict:
-        """Add environment variables for a Cloud Run Job.
-
-        Method `self._base_environment()` gets necessary Prefect environment variables
-        from the config.
-
-        See: https://cloud.google.com/run/docs/reference/rest/v1/Container#envvar for
-        how environment variables are specified for Cloud Run Jobs.
-        """  # noqa
-        env = {**self._base_environment(), **self.env}
-        cloud_run_env = [{"name": k, "value": v} for k, v in env.items()]
-        return {"env": cloud_run_env}
-
 
 class CloudRunWorkerVariables(BaseVariables):
+    region: str = Field(..., description="The region where the Cloud Run Job resides.")
+    credentials: GcpCredentials  # cannot be Field; else it shows as Json
     image: Optional[str] = Field(
         default=None,
         title="Image Name",
@@ -218,38 +186,6 @@ class CloudRunWorkerVariables(BaseVariables):
             "for supported image registries. If not set, the latest Prefect image will be used."
         ),
         example="docker.io/prefecthq/prefect:2-latest",
-    )
-    region: str = Field(..., description="The region where the Cloud Run Job resides.")
-    credentials: GcpCredentials  # cannot be Field; else it shows as Json
-
-    # Job settings
-    cpu: Optional[int] = Field(
-        default=None,
-        title="CPU",
-        description=(
-            "The amount of compute allocated to the Cloud Run Job. "
-            "The int must be valid based on the rules specified at "
-            "https://cloud.google.com/run/docs/configuring/cpu#setting-jobs ."
-        ),
-    )
-    memory: Optional[int] = Field(
-        default=None,
-        title="Memory",
-        description="The amount of memory allocated to the Cloud Run Job.",
-    )
-    memory_unit: Optional[Literal["G", "Gi", "M", "Mi"]] = Field(
-        default=None,
-        title="Memory Units",
-        description=(
-            "The unit of memory. See "
-            "https://cloud.google.com/run/docs/configuring/memory-limits#setting "
-            "for additional details."
-        ),
-    )
-    vpc_connector_name: Optional[str] = Field(
-        default=None,
-        title="VPC Connector Name",
-        description="The name of the VPC connector to use for the Cloud Run Job.",
     )
     args: Optional[List[str]] = Field(
         default=None,
@@ -283,35 +219,9 @@ class CloudRunWorker(BaseWorker):
     job_configuration = CloudRunWorkerJobConfiguration
     job_configuration_variables = CloudRunWorkerVariables
 
-    async def _check_flow_run(self, flow_run: "FlowRun") -> None:
-        pass
-
-    @property
-    def memory_string(self):
-        """Returns the string expected for memory resources argument."""
-        if self.memory and self.memory_unit:
-            return str(self.memory) + self.memory_unit
-        return None
-
-    @validator("image")
-    def _remove_image_spaces(cls, value):
-        """Deal with spaces in image names."""
-        if value is not None:
-            return value.strip()
-
-    @root_validator
-    def _check_valid_memory(cls, values):
-        """Make sure memory conforms to expected values for API.
-        See: https://cloud.google.com/run/docs/configuring/memory-limits#setting
-        """  # noqa
-        if (values.get("memory") is not None and values.get("memory_unit") is None) or (
-            values.get("memory_unit") is not None and values.get("memory") is None
-        ):
-            raise ValueError(
-                "A memory value and unit must both be supplied to specify a memory"
-                " value other than the default memory value."
-            )
-        return values
+    # TODO: remove
+    # async def _check_flow_run(self, flow_run: "FlowRun") -> None:
+    #     pass
 
     def _create_job_error(self, exc, configuration):
         """Provides a nicer error for 404s when trying to create a Cloud Run Job."""
@@ -350,13 +260,6 @@ class CloudRunWorker(BaseWorker):
 
         raise exc
 
-    def _cpu_as_k8s_quantity(self) -> str:
-        """Return the CPU integer in the format expected by GCP Cloud Run Jobs API.
-        See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        See also: https://cloud.google.com/run/docs/configuring/cpu#setting-jobs
-        """  # noqa
-        return str(self.cpu * 1000) + "m"
-
     @sync_compatible
     async def run(
         self,
@@ -364,7 +267,6 @@ class CloudRunWorker(BaseWorker):
         configuration: CloudRunWorkerJobConfiguration,
         task_status: Optional[anyio.abc.TaskStatus] = None,
     ) -> BaseWorkerResult:
-
         with self._get_client(configuration) as client:
             await run_sync_in_worker_thread(
                 self._create_job_and_wait_for_registration, configuration, client
@@ -395,7 +297,9 @@ class CloudRunWorker(BaseWorker):
             "run", "v1", client_options=options, credentials=gcp_creds
         ).namespaces()
 
-    def _create_job_and_wait_for_registration(self, configuration: CloudRunWorkerJobConfiguration, client: Resource) -> None:
+    def _create_job_and_wait_for_registration(
+        self, configuration: CloudRunWorkerJobConfiguration, client: Resource
+    ) -> None:
         """Create a new job wait for it to finish registering."""
         try:
             self._logger.info(f"Creating Cloud Run Job {configuration.job_name}")
@@ -431,7 +335,9 @@ class CloudRunWorker(BaseWorker):
                     )
             raise
 
-    def _begin_job_execution(self, configuration: CloudRunWorkerJobConfiguration, client: Resource) -> Execution:
+    def _begin_job_execution(
+        self, configuration: CloudRunWorkerJobConfiguration, client: Resource
+    ) -> Execution:
         """Submit a job run for execution and return the execution object."""
         try:
             self._logger.info(
@@ -454,7 +360,11 @@ class CloudRunWorker(BaseWorker):
         return job_execution
 
     def _watch_job_execution_and_get_result(
-        self, configuration: CloudRunWorkerJobConfiguration, client: Resource, execution: Execution, poll_interval: int=5
+        self,
+        configuration: CloudRunWorkerJobConfiguration,
+        client: Resource,
+        execution: Execution,
+        poll_interval: int = 5,
     ) -> CloudRunWorkerResult:
         """Wait for execution to complete and then return result."""
         try:
@@ -473,7 +383,9 @@ class CloudRunWorker(BaseWorker):
 
         if job_execution.succeeded():
             status_code = 0
-            self._logger.info(f"Job Run {configuration.job_name} completed successfully")
+            self._logger.info(
+                f"Job Run {configuration.job_name} completed successfully"
+            )
         else:
             status_code = 1
             error_msg = job_execution.condition_after_completion()["message"]
@@ -502,7 +414,9 @@ class CloudRunWorker(BaseWorker):
                     f" Run Job {configuration.job_name}"
                 )
 
-        return CloudRunWorkerResult(identifier=configuration.job_name, status_code=status_code)
+        return CloudRunWorkerResult(
+            identifier=configuration.job_name, status_code=status_code
+        )
 
     def _watch_job_execution(
         self, client, job_execution: Execution, timeout: int, poll_interval: int = 5
@@ -530,11 +444,16 @@ class CloudRunWorker(BaseWorker):
         return job_execution
 
     def _wait_for_job_creation(
-        self, client: Resource, configuration: CloudRunWorkerJobConfiguration, poll_interval: int = 5
+        self,
+        client: Resource,
+        configuration: CloudRunWorkerJobConfiguration,
+        poll_interval: int = 5,
     ):
         """Give created job time to register."""
         job = Job.get(
-            client=client, namespace=configuration.project, job_name=configuration.job_name
+            client=client,
+            namespace=configuration.project,
+            job_name=configuration.job_name,
         )
 
         t0 = time.time()
@@ -554,7 +473,10 @@ class CloudRunWorker(BaseWorker):
             )
 
             elapsed_time = time.time() - t0
-            if configuration.timeout is not None and elapsed_time > configuration.timeout:
+            if (
+                configuration.timeout is not None
+                and elapsed_time > configuration.timeout
+            ):
                 raise RuntimeError(
                     f"Timed out after {elapsed_time}s while waiting for Cloud Run Job "
                     "execution to complete. Your job may still be running on GCP."

--- a/tests/test_cloud_run.py
+++ b/tests/test_cloud_run.py
@@ -765,7 +765,6 @@ class TestCloudRunJobRun:
         with pytest.raises(Exception):
             cloud_run_job.run()
         calls = list_mock_calls(mock_client, 2)
-        # breakpoint()
         for call, expected_call in zip(calls, expected_calls):
             assert call.startswith(expected_call)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -62,9 +62,6 @@ def cloud_run_worker():
 
 
 class TestCloudRunWorkerJobConfiguration:
-    def test_project_property(self, mock_credentials, cloud_run_worker_job_config):
-        assert cloud_run_worker_job_config.project == "my_project"
-
     def test_job_name(self, cloud_run_worker_job_config):
         cloud_run_worker_job_config.job_body["metadata"]["name"] = "my-job-name"
         assert cloud_run_worker_job_config.job_name == "my-job-name"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -222,7 +222,8 @@ class TestCloudRunWorkerJobConfiguration:
                     "Job has incompatible values for the following attributes: "
                     "/apiVersion must have value 'run.googleapis.com/v1', "
                     "/kind must have value 'Job', "
-                    "/metadata/annotations/run.googleapis.com~1launch-stage must have value 'BETA'"
+                    "/metadata/annotations/run.googleapis.com~1launch-stage "
+                    "must have value 'BETA'"
                 ),
                 "type": "value_error",
             }

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -634,6 +634,5 @@ class TestCloudRunWorker:
             with pytest.raises(Exception):
                 await cloud_run_worker.run(flow_run, cloud_run_worker_job_config)
             calls = list_mock_calls(mock_client, 2)
-            # breakpoint()
             for call, expected_call in zip(calls, expected_calls):
                 assert call.startswith(expected_call)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,10 +1,13 @@
 import uuid
 from unittest.mock import Mock
 
+import anyio
 import pydantic
 import pytest
+from googleapiclient.errors import HttpError
 from jsonschema.exceptions import ValidationError
 from prefect.client.schemas import FlowRun
+from prefect.exceptions import InfrastructureNotFound
 from prefect.server.schemas.actions import DeploymentCreate
 
 from prefect_gcp.credentials import GcpCredentials
@@ -636,3 +639,69 @@ class TestCloudRunWorker:
             calls = list_mock_calls(mock_client, 2)
             for call, expected_call in zip(calls, expected_calls):
                 assert call.startswith(expected_call)
+
+    async def test_kill(self, mock_client, cloud_run_worker_job_config, flow_run):
+        async with CloudRunWorker("my-work-pool") as cloud_run_worker:
+            cloud_run_worker_job_config.prepare_for_flow_run(flow_run, None, None)
+
+            mock_client.jobs().get().execute.return_value = self.job_ready
+            mock_client.jobs().run().execute.return_value = self.job_ready
+            mock_client.executions().get().execute.return_value = (
+                self.execution_not_found
+            )  # noqa
+
+            with anyio.fail_after(5):
+                async with anyio.create_task_group() as tg:
+                    identifier = await tg.start(
+                        cloud_run_worker.run, flow_run, cloud_run_worker_job_config
+                    )
+                    await cloud_run_worker.kill_infrastructure(
+                        identifier, cloud_run_worker_job_config
+                    )
+
+            actual_calls = list_mock_calls(mock_client=mock_client)
+            assert "call.jobs().delete().execute()" in actual_calls
+
+    def failed_to_get(self):
+        raise HttpError(Mock(reason="does not exist"), content=b"")
+
+    async def test_kill_not_found(
+        self, mock_client, cloud_run_worker_job_config, flow_run
+    ):
+        async with CloudRunWorker("my-work-pool") as cloud_run_worker:
+            cloud_run_worker_job_config.prepare_for_flow_run(flow_run, None, None)
+
+            mock_client.jobs().delete().execute.side_effect = self.failed_to_get
+            with pytest.raises(
+                InfrastructureNotFound, match="Cannot stop Cloud Run Job; the job name"
+            ):
+                await cloud_run_worker.kill_infrastructure(
+                    "non-existent", cloud_run_worker_job_config
+                )
+
+    async def test_kill_grace_seconds(
+        self, mock_client, cloud_run_worker_job_config, flow_run, caplog
+    ):
+        async with CloudRunWorker("my-work-pool") as cloud_run_worker:
+            cloud_run_worker_job_config.prepare_for_flow_run(flow_run, None, None)
+
+            mock_client.jobs().get().execute.return_value = self.job_ready
+            mock_client.jobs().run().execute.return_value = self.job_ready
+            mock_client.executions().get().execute.return_value = (
+                self.execution_not_found
+            )
+
+            with anyio.fail_after(5):
+                async with anyio.create_task_group() as tg:
+                    identifier = await tg.start(
+                        cloud_run_worker.run, flow_run, cloud_run_worker_job_config
+                    )
+                    await cloud_run_worker.kill_infrastructure(
+                        identifier, cloud_run_worker_job_config, grace_seconds=42
+                    )
+
+            for record in caplog.records:
+                if "Kill grace period of 42s requested, but GCP does not" in record.msg:
+                    break
+            else:
+                raise AssertionError("Expected message not found.")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,14 +1,16 @@
-import pytest
 from unittest.mock import Mock
-from prefect_gcp.worker import (
-    CloudRunWorkerJobConfiguration,
-    CloudRunWorker,
-    CloudRunWorkerVariables,
-    CloudRunWorkerResult,
-)
-from prefect_gcp.credentials import GcpCredentials
+
+import pytest
 from prefect.client.schemas import FlowRun
 from pydantic import ValidationError
+
+from prefect_gcp.credentials import GcpCredentials
+from prefect_gcp.worker import (
+    CloudRunWorker,
+    CloudRunWorkerJobConfiguration,
+    CloudRunWorkerResult,
+    CloudRunWorkerVariables,
+)
 
 
 @pytest.fixture
@@ -178,7 +180,8 @@ class TestCloudRunWorkerJobConfiguration:
                 "msg": (
                     "Job is missing required attributes at the following paths: "
                     "/metadata/annotations, "
-                    "/spec/template/spec/template/spec/containers"),
+                    "/spec/template/spec/template/spec/containers"
+                ),
                 "type": "value_error",
             }
         ]
@@ -217,7 +220,8 @@ class TestCloudRunWorkerJobConfiguration:
                     "Job has incompatible values for the following attributes: "
                     "/apiVersion must have value 'run.googleapis.com/v1', "
                     "/kind must have value 'Job', "
-                    "/metadata/annotations/run.googleapis.com~1launch-stage must have value 'BETA'"),
+                    "/metadata/annotations/run.googleapis.com~1launch-stage must have value 'BETA'"
+                ),
                 "type": "value_error",
             }
         ]
@@ -410,7 +414,13 @@ class TestCloudRunWorker:
         ],
     )
     def test_happy_path_api_calls_made_correctly(
-        self, mock_client, cloud_run_worker, cloud_run_worker_job_config, keep_job, flow_run, expected_calls
+        self,
+        mock_client,
+        cloud_run_worker,
+        cloud_run_worker_job_config,
+        keep_job,
+        flow_run,
+        expected_calls,
     ):
         """Expected behavior:
         Happy path:
@@ -433,7 +443,9 @@ class TestCloudRunWorker:
         for call, expected_call in zip(calls, expected_calls):
             assert call.startswith(expected_call)
 
-    def test_happy_path_result(self, mock_client, cloud_run_worker, cloud_run_worker_job_config, flow_run):
+    def test_happy_path_result(
+        self, mock_client, cloud_run_worker, cloud_run_worker_job_config, flow_run
+    ):
         """Expected behavior: returns a CloudrunJobResult with status_code 0"""
         cloud_run_worker_job_config.keep_job = True
         cloud_run_worker_job_config.prepare_for_flow_run(flow_run, None, None)
@@ -468,7 +480,14 @@ class TestCloudRunWorker:
         ],
     )
     def test_behavior_called_when_job_get_fails(
-        self, monkeypatch, mock_client, cloud_run_worker, cloud_run_worker_job_config, flow_run, keep_job, expected_calls
+        self,
+        monkeypatch,
+        mock_client,
+        cloud_run_worker,
+        cloud_run_worker_job_config,
+        flow_run,
+        keep_job,
+        expected_calls,
     ):
         """Expected behavior:
         When job create is called, but there is a subsequent exception on a get,
@@ -520,7 +539,14 @@ class TestCloudRunWorker:
         ],
     )
     def test_behavior_called_when_execution_get_fails(
-        self, monkeypatch, mock_client, cloud_run_worker, cloud_run_worker_job_config, flow_run, keep_job, expected_calls
+        self,
+        monkeypatch,
+        mock_client,
+        cloud_run_worker,
+        cloud_run_worker_job_config,
+        flow_run,
+        keep_job,
+        expected_calls,
     ):
         """Expected behavior:
         Job creation is called successfully, the job is found when `get` is called,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -268,18 +268,6 @@ class TestCloudRunWorkerJobConfiguration:
 
 
 class TestCloudRunWorkerValidConfiguration:
-    def test_region_is_required(self):
-        deployment = DeploymentCreate(
-            name="my-deployment", flow_id=uuid.uuid4(), infra_overrides={}
-        )
-
-        with pytest.raises(ValidationError) as excinfo:
-            deployment.check_valid_configuration(
-                CloudRunWorker.get_default_base_job_template()
-            )
-
-        assert excinfo.value.message == "'region' is a required property"
-
     @pytest.mark.parametrize("cpu", ["1", "100", "100m", "1500m"])
     def test_invalid_cpu_string(self, cpu):
         deployment = DeploymentCreate(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -13,6 +13,11 @@ from prefect_gcp.worker import (
 )
 
 
+@pytest.fixture(autouse=True)
+def mock_credentials(gcp_credentials):
+    yield
+
+
 @pytest.fixture
 def jobs_body():
     return {

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock
 
 import pytest
 from prefect.client.schemas import FlowRun
-from prefect.server.schemas.core import WorkPool, Deployment
 from pydantic import ValidationError
 
 from prefect_gcp.credentials import GcpCredentials
@@ -12,11 +11,6 @@ from prefect_gcp.worker import (
     CloudRunWorkerResult,
     CloudRunWorkerVariables,
 )
-
-
-@pytest.fixture
-def work_pool():
-    return
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -62,8 +62,8 @@ def cloud_run_worker():
 
 
 class TestCloudRunWorkerJobConfiguration:
-    def test_project_property(self, service_account_info, cloud_run_worker_job_config):
-        assert cloud_run_worker_job_config.project == service_account_info["project_id"]
+    def test_project_property(self, mock_credentials, cloud_run_worker_job_config):
+        assert cloud_run_worker_job_config.project == "my_project"
 
     def test_job_name(self, cloud_run_worker_job_config):
         cloud_run_worker_job_config.job_body["metadata"]["name"] = "my-job-name"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,545 @@
+import pytest
+from unittest.mock import Mock
+from prefect_gcp.worker import (
+    CloudRunWorkerJobConfiguration,
+    CloudRunWorker,
+    CloudRunWorkerVariables,
+    CloudRunWorkerResult,
+)
+from prefect_gcp.credentials import GcpCredentials
+from prefect.client.schemas import FlowRun
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def jobs_body():
+    return {
+        "apiVersion": "run.googleapis.com/v1",
+        "kind": "Job",
+        "metadata": {
+            "annotations": {
+                # See: https://cloud.google.com/run/docs/troubleshooting#launch-stage-validation  # noqa
+                "run.googleapis.com/launch-stage": "BETA",
+            },
+        },
+        "spec": {  # JobSpec
+            "template": {  # ExecutionTemplateSpec
+                "spec": {  # ExecutionSpec
+                    "template": {  # TaskTemplateSpec
+                        "spec": {"containers": [{}]},  # TaskSpec
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def flow_run():
+    return FlowRun(name="my-flow-run-name")
+
+
+@pytest.fixture
+def cloud_run_worker_job_config(service_account_info, jobs_body, flow_run):
+    return CloudRunWorkerJobConfiguration(
+        image="gcr.io//not-a/real-image",
+        region="middle-earth2",
+        job_body=jobs_body,
+        credentials=GcpCredentials(service_account_info=service_account_info),
+    )
+
+
+@pytest.fixture
+def cloud_run_worker():
+    return CloudRunWorker("my-work-pool")
+
+
+class TestCloudRunWorkerJobConfiguration:
+    def test_project_property(self, service_account_info, cloud_run_worker_job_config):
+        assert cloud_run_worker_job_config.project == service_account_info["project_id"]
+
+    def test_job_name(self, cloud_run_worker_job_config):
+        cloud_run_worker_job_config.job_body["metadata"]["name"] = "my-job-name"
+        assert cloud_run_worker_job_config.job_name == "my-job-name"
+
+    def test_populate_envs(
+        self,
+        cloud_run_worker_job_config,
+    ):
+        container = cloud_run_worker_job_config.job_body["spec"]["template"]["spec"][
+            "template"
+        ]["spec"]["containers"][0]
+
+        assert "env" not in container
+        assert cloud_run_worker_job_config.env == {}
+        cloud_run_worker_job_config.env = {"a": "b"}
+
+        cloud_run_worker_job_config._populate_envs()
+
+        assert "env" in container
+        assert len(container["env"]) == 1
+        assert container["env"][0]["name"] == "a"
+        assert container["env"][0]["value"] == "b"
+
+    def test_populate_image_if_not_present(self, cloud_run_worker_job_config):
+        container = cloud_run_worker_job_config.job_body["spec"]["template"]["spec"][
+            "template"
+        ]["spec"]["containers"][0]
+
+        assert "image" not in container
+
+        cloud_run_worker_job_config._populate_image_if_not_present()
+
+        # defaults to prefect image
+        assert "image" in container
+        assert container["image"].startswith("docker.io/prefecthq/prefect:")
+
+    def test_populate_image_doesnt_overwrite(self, cloud_run_worker_job_config):
+        image = "my-first-image"
+        container = cloud_run_worker_job_config.job_body["spec"]["template"]["spec"][
+            "template"
+        ]["spec"]["containers"][0]
+        container["image"] = image
+
+        cloud_run_worker_job_config._populate_image_if_not_present()
+
+        assert container["image"] == image
+
+    def test_populate_args_if_not_present(self, cloud_run_worker_job_config):
+        container = cloud_run_worker_job_config.job_body["spec"]["template"]["spec"][
+            "template"
+        ]["spec"]["containers"][0]
+
+        assert "args" not in container
+
+        cloud_run_worker_job_config._populate_command_if_not_present()
+
+        assert "args" in container
+        assert container["args"] == ["python", "-m", "prefect.engine"]
+
+    def test_populate_name_if_not_present(self, cloud_run_worker_job_config, flow_run):
+        metadata = cloud_run_worker_job_config.job_body["metadata"]
+
+        assert "name" not in metadata
+
+        cloud_run_worker_job_config._populate_name_if_not_present(flow_run)
+
+        assert "name" in metadata
+        assert metadata["name"] == flow_run.name
+
+    def test_populate_name_doesnt_overwrite(
+        self, cloud_run_worker_job_config, flow_run
+    ):
+        name = "my-name"
+        metadata = cloud_run_worker_job_config.job_body["metadata"]
+        metadata["name"] = name
+
+        cloud_run_worker_job_config._populate_name_if_not_present(flow_run)
+
+        assert "name" in metadata
+        assert metadata["name"] != flow_run.name
+        assert metadata["name"] == name
+
+    async def test_validates_against_an_empty_job_body(self):
+        template = CloudRunWorker.get_default_base_job_template()
+        template["job_configuration"]["job_body"] = {}
+        template["job_configuration"]["region"] = "test-region1"
+
+        with pytest.raises(ValidationError) as excinfo:
+            await CloudRunWorkerJobConfiguration.from_template_and_values(template, {})
+
+        assert excinfo.value.errors() == [
+            {
+                "loc": ("job_body",),
+                "msg": (
+                    "Job is missing required attributes at the following paths: "
+                    "/apiVersion, /kind, /metadata, /spec"
+                ),
+                "type": "value_error",
+            }
+        ]
+
+    async def test_validates_for_a_job_body_missing_deeper_attributes(self):
+        template = CloudRunWorker.get_default_base_job_template()
+        template["job_configuration"]["job_body"] = {
+            "apiVersion": "run.googleapis.com/v1",
+            "kind": "Job",
+            "metadata": {},
+            "spec": {"template": {"spec": {"template": {"spec": {}}}}},
+        }
+        template["job_configuration"]["region"] = "test-region1"
+
+        with pytest.raises(ValidationError) as excinfo:
+            await CloudRunWorkerJobConfiguration.from_template_and_values(template, {})
+
+        assert excinfo.value.errors() == [
+            {
+                "loc": ("job_body",),
+                "msg": (
+                    "Job is missing required attributes at the following paths: "
+                    "/metadata/annotations, "
+                    "/spec/template/spec/template/spec/containers"),
+                "type": "value_error",
+            }
+        ]
+
+    async def test_validates_for_a_job_with_incompatible_values(self):
+        """We should give a human-friendly error when the user provides a custom Job
+        manifest that is attempting to change required values."""
+        template = CloudRunWorker.get_default_base_job_template()
+        template["job_configuration"]["region"] = "test-region1"
+        template["job_configuration"]["job_body"] = {
+            "apiVersion": "v1",
+            "kind": "NOTAJOB",
+            "metadata": {
+                "annotations": {
+                    "run.googleapis.com/launch-stage": "NOTABETA",
+                },
+            },
+            "spec": {  # JobSpec
+                "template": {  # ExecutionTemplateSpec
+                    "spec": {  # ExecutionSpec
+                        "template": {  # TaskTemplateSpec
+                            "spec": {"containers": [{}]},  # TaskSpec
+                        },
+                    },
+                },
+            },
+        }
+
+        with pytest.raises(ValidationError) as excinfo:
+            await CloudRunWorkerJobConfiguration.from_template_and_values(template, {})
+
+        assert excinfo.value.errors() == [
+            {
+                "loc": ("job_body",),
+                "msg": (
+                    "Job has incompatible values for the following attributes: "
+                    "/apiVersion must have value 'run.googleapis.com/v1', "
+                    "/kind must have value 'Job', "
+                    "/metadata/annotations/run.googleapis.com~1launch-stage must have value 'BETA'"),
+                "type": "value_error",
+            }
+        ]
+
+
+class TestCloudRunWorkerVariables:
+    def test_region_is_required(self):
+        with pytest.raises(ValidationError) as excinfo:
+            CloudRunWorkerVariables()
+        assert excinfo.value.errors() == [
+            {"loc": ("region",), "msg": "field required", "type": "value_error.missing"}
+        ]
+
+    def test_valid_cpu_string(self):
+        with pytest.raises(ValidationError):
+            CloudRunWorkerVariables(region="test-region1", cpu="1")
+        with pytest.raises(ValidationError):
+            CloudRunWorkerVariables(region="test-region1", cpu="100")
+        with pytest.raises(ValidationError):
+            CloudRunWorkerVariables(region="test-region1", cpu="100m")
+        with pytest.raises(ValidationError):
+            CloudRunWorkerVariables(region="test-region1", cpu="1500m")
+
+        CloudRunWorkerVariables(region="test-region1", cpu="1000m")
+        CloudRunWorkerVariables(region="test-region1", cpu="2000m")
+        CloudRunWorkerVariables(region="test-region1", cpu="3000m")
+
+    def test_valid_memory_string(self):
+        with pytest.raises(ValidationError):
+            CloudRunWorkerVariables(region="test-region1", memory="1")
+        with pytest.raises(ValidationError):
+            CloudRunWorkerVariables(region="test-region1", memory="100")
+        with pytest.raises(ValidationError):
+            CloudRunWorkerVariables(region="test-region1", memory="100Gigs")
+
+        CloudRunWorkerVariables(region="test-region1", memory="512G")
+        CloudRunWorkerVariables(region="test-region1", memory="512Gi")
+        CloudRunWorkerVariables(region="test-region1", memory="512M")
+        CloudRunWorkerVariables(region="test-region1", memory="512Mi")
+
+
+executions_return_value = {
+    "metadata": {"name": "test-name", "namespace": "test-namespace"},
+    "spec": {"MySpec": "spec"},
+    "status": {"logUri": "test-log-uri"},
+}
+
+jobs_return_value = {
+    "metadata": {"name": "Test", "namespace": "test-namespace"},
+    "spec": {"MySpec": "spec"},
+    "status": {
+        "conditions": [{"type": "Ready", "dog": "cat"}],
+        "latestCreatedExecution": {"puppy": "kitty"},
+    },
+}
+
+
+@pytest.fixture
+def mock_client(monkeypatch, mock_credentials):
+    m = Mock(name="MockClient")
+
+    def mock_enter(m, *args, **kwargs):
+        return m
+
+    def mock_exit(m, *args, **kwargs):
+        pass
+
+    m.__enter__ = mock_enter
+    m.__exit__ = mock_exit
+
+    def get_mock_client(*args, **kwargs):
+        return m
+
+    monkeypatch.setattr(
+        "prefect_gcp.worker.CloudRunWorker._get_client",
+        get_mock_client,
+    )
+
+    return m
+
+
+class MockExecution(Mock):
+    call_count = 0
+
+    def __init__(self, succeeded=False, *args, **kwargs):
+        super().__init__()
+        self.log_uri = "test_uri"
+        self._succeeded = succeeded
+
+    def is_running(self):
+        MockExecution.call_count += 1
+
+        if self.call_count > 2:
+            return False
+        return True
+
+    def condition_after_completion(self):
+        return {"message": "test"}
+
+    def succeeded(self):
+        return self._succeeded
+
+    @classmethod
+    def get(cls, *args, **kwargs):
+        return cls()
+
+
+def list_mock_calls(mock_client, assigned_calls=0):
+    calls = []
+    for call in mock_client.mock_calls:
+        # mock `call.jobs().get()` results in two calls: `call.jobs()` and
+        # `call.jobs().get()`, so we want to remove the first, smaller
+        # call.
+        if len(str(call).split(".")) > 2:
+            calls.append(str(call))
+    # assigning a return value to a call results in initial
+    # mock calls which are not actually made
+    actual_calls = calls[assigned_calls:]
+
+    return actual_calls
+
+
+class TestCloudRunWorker:
+    job_ready = {
+        "metadata": {"name": "Test", "namespace": "test-namespace"},
+        "spec": {"MySpec": "spec"},
+        "status": {
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "latestCreatedExecution": {"puppy": "kitty"},
+        },
+    }
+    execution_ready = {
+        "metadata": {"name": "test-name", "namespace": "test-namespace"},
+        "spec": {"MySpec": "spec"},
+        "status": {"logUri": "test-log-uri"},
+    }
+    execution_complete_and_succeeded = {
+        "metadata": {"name": "test-name", "namespace": "test-namespace"},
+        "spec": {"MySpec": "spec"},
+        "status": {
+            "logUri": "test-log-uri",
+            "completionTime": "Done!",
+            "conditions": [{"type": "Completed", "status": "True"}],
+        },
+    }
+    execution_not_found = {
+        "metadata": {"name": "test-name", "namespace": "test-namespace"},
+        "spec": {"MySpec": "spec"},
+        "status": {
+            "logUri": "test-log-uri",
+            "completionTime": "Done!",
+            "conditions": [
+                {"type": "Completed", "status": "False", "message": "Not found"}
+            ],
+        },
+    }
+    execution_complete_and_failed = {
+        "metadata": {"name": "test-name", "namespace": "test-namespace"},
+        "spec": {"MySpec": "spec"},
+        "status": {
+            "logUri": "test-log-uri",
+            "completionTime": "Done!",
+            "conditions": [
+                {"type": "Completed", "status": "False", "message": "test failure"}
+            ],
+        },
+    }
+
+    @pytest.mark.parametrize(
+        "keep_job,expected_calls",
+        [
+            (
+                True,
+                [
+                    "call.jobs().create",
+                    "call.jobs().create().execute()",
+                ],
+            ),
+            (
+                False,
+                [
+                    "call.jobs().create",
+                    "call.jobs().create().execute()",
+                    "call.jobs().get",
+                    "call.jobs().get().execute()",
+                    "call.jobs().run",
+                    "call.jobs().run().execute()",
+                ],
+            ),
+        ],
+    )
+    def test_happy_path_api_calls_made_correctly(
+        self, mock_client, cloud_run_worker, cloud_run_worker_job_config, keep_job, flow_run, expected_calls
+    ):
+        """Expected behavior:
+        Happy path:
+        - A call to Job.create and execute
+        - A call to Job.get and execute (check status)
+        - A call to Job.run and execute (start the job when status is ready)
+        - A call to Executions.get and execute (see the status of the Execution)
+        - A call to Job.delete and execute if `keep_job` False, otherwise no call
+        """
+        cloud_run_worker_job_config.keep_job = keep_job
+        cloud_run_worker_job_config.prepare_for_flow_run(flow_run, None, None)
+        mock_client.jobs().get().execute.return_value = self.job_ready
+        mock_client.jobs().run().execute.return_value = self.job_ready
+        mock_client.executions().get().execute.return_value = (
+            self.execution_complete_and_succeeded
+        )
+        cloud_run_worker.run(flow_run, cloud_run_worker_job_config)
+        calls = list_mock_calls(mock_client, 3)
+
+        for call, expected_call in zip(calls, expected_calls):
+            assert call.startswith(expected_call)
+
+    def test_happy_path_result(self, mock_client, cloud_run_worker, cloud_run_worker_job_config, flow_run):
+        """Expected behavior: returns a CloudrunJobResult with status_code 0"""
+        cloud_run_worker_job_config.keep_job = True
+        cloud_run_worker_job_config.prepare_for_flow_run(flow_run, None, None)
+        mock_client.jobs().get().execute.return_value = self.job_ready
+        mock_client.jobs().run().execute.return_value = self.job_ready
+        mock_client.executions().get().execute.return_value = (
+            self.execution_complete_and_succeeded
+        )
+        res = cloud_run_worker.run(flow_run, cloud_run_worker_job_config)
+        assert isinstance(res, CloudRunWorkerResult)
+        assert res.status_code == 0
+
+    @pytest.mark.parametrize(
+        "keep_job,expected_calls",
+        [
+            (
+                True,
+                [
+                    "call.jobs().create",
+                    "call.jobs().create().execute()",
+                ],
+            ),
+            (
+                False,
+                [
+                    "call.jobs().create",
+                    "call.jobs().create().execute()",
+                    "call.jobs().delete",
+                    "call.jobs().delete().execute()",
+                ],
+            ),
+        ],
+    )
+    def test_behavior_called_when_job_get_fails(
+        self, monkeypatch, mock_client, cloud_run_worker, cloud_run_worker_job_config, flow_run, keep_job, expected_calls
+    ):
+        """Expected behavior:
+        When job create is called, but there is a subsequent exception on a get,
+        there should be a delete call for that job if `keep_job` is False
+        """
+        cloud_run_worker_job_config.keep_job = keep_job
+
+        # Getting job will raise error
+        def raise_exception(*args, **kwargs):
+            raise Exception("This is an intentional exception")
+
+        monkeypatch.setattr("prefect_gcp.cloud_run.Job.get", raise_exception)
+
+        with pytest.raises(Exception):
+            cloud_run_worker.run(flow_run, cloud_run_worker_job_config)
+        calls = list_mock_calls(mock_client, 0)
+
+        for call, expected_call in zip(calls, expected_calls):
+            assert call.startswith(expected_call)
+
+    # Test that RuntimeError raised if something happens with execution
+    @pytest.mark.parametrize(
+        "keep_job,expected_calls",
+        [
+            (
+                True,
+                [
+                    "call.jobs().create",
+                    "call.jobs().create().execute()",
+                    "call.jobs().get",
+                    "call.jobs().get().execute()",
+                    "call.jobs().run",
+                    "call.jobs().run().execute()",
+                ],
+            ),
+            (
+                False,
+                [
+                    "call.jobs().create",
+                    "call.jobs().create().execute()",
+                    "call.jobs().get",
+                    "call.jobs().get().execute()",
+                    "call.jobs().run",
+                    "call.jobs().run().execute()",
+                    "call.jobs().delete",
+                    "call.jobs().delete().execute()",
+                ],
+            ),
+        ],
+    )
+    def test_behavior_called_when_execution_get_fails(
+        self, monkeypatch, mock_client, cloud_run_worker, cloud_run_worker_job_config, flow_run, keep_job, expected_calls
+    ):
+        """Expected behavior:
+        Job creation is called successfully, the job is found when `get` is called,
+        job `run` is called, but the execution fails, there should be a delete
+        call for that job if `keep_job` is False, and an exception should be raised.
+        """
+        cloud_run_worker_job_config.keep_job = keep_job
+        mock_client.jobs().get().execute.return_value = self.job_ready
+        mock_client.jobs().run().execute.return_value = self.job_ready
+
+        # Getting execution will raise error
+        def raise_exception(*args, **kwargs):
+            raise Exception("This is an intentional exception")
+
+        monkeypatch.setattr("prefect_gcp.cloud_run.Execution.get", raise_exception)
+
+        with pytest.raises(Exception):
+            cloud_run_worker.run(flow_run, cloud_run_worker_job_config)
+        calls = list_mock_calls(mock_client, 2)
+        # breakpoint()
+        for call, expected_call in zip(calls, expected_calls):
+            assert call.startswith(expected_call)


### PR DESCRIPTION
Adds the `CloudRuWorker`

Functionality has been taken from the `CloudRunJob` infrastructure block and ported over to the `Worker` paradigm.

## Example
```
pip install prefect-gcp
```

Start a Cloud Run Job Worker
```
prefect worker start -p 'my-work-pool' --type cloud-run
```

By default the `CloudRunWorker` will use a base jobs body with placeholders. These are populated from `CloudRunWorkerVariables`. 

```json
{
        "apiVersion": "run.googleapis.com/v1",
        "kind": "Job",
        "metadata": {
            "name": "{{ name }}",
            "annotations": {
                "run.googleapis.com/launch-stage": "BETA",
                "run.googleapis.com/vpc-access-connector": "{{ vpc_connector_name }}",
            },
        },
        "spec": {
            "template": { 
                "spec": {
                    "template": {
                        "spec": {
                            "containers": [
                                {
                                    "image": "{{ image }}",
                                    "args": "{{ args }}",
                                    "resources": {
                                        "limits": {
                                            "cpu": "{{ cpu }}",
                                            "memory": "{{ memory }}",
                                        },
                                        "requests": {
                                            "cpu": "{{ cpu }}",
                                            "memory": "{{ memory }}",
                                        },
                                    },
                                }
                            ],
                            "timeoutSeconds": "{{ timeout }}",
                            "serviceAccountName": "{{ service_account_name }}",
                        }
                    },
                },
            },
        },
    }
```

Similar to other workers using this base templating pattern allows us to provide a convenient way to add specific placeholders, as well as letting more advanced customization by modifying the actual template on a per work pool basis.
