### PR TITLE
Add accelerator_count for VertexAICustomTrainingJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Added optional `accelerator_count` property for `VertexAICustomTrainingJob`.
 
 ### Changed
 

--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -138,6 +138,9 @@ class VertexAICustomTrainingJob(Infrastructure):
     accelerator_type: Optional[str] = Field(
         default=None, description="The type of accelerator to attach to the machine."
     )
+    accelerator_count: Optional[int] = Field(
+        default=None, description="The number of accelerators to attach to the machine."
+    )
     maximum_run_time: datetime.timedelta = Field(
         default=datetime.timedelta(days=7), description="The maximum job running time."
     )
@@ -215,7 +218,9 @@ class VertexAICustomTrainingJob(Infrastructure):
             image_uri=self.image, command=self.command, args=[], env=env_list
         )
         machine_spec = MachineSpec(
-            machine_type=self.machine_type, accelerator_type=self.accelerator_type
+            machine_type=self.machine_type,
+            accelerator_type=self.accelerator_type,
+            accelerator_count=self.accelerator_count,
         )
         worker_pool_spec = WorkerPoolSpec(
             container_spec=container_spec, machine_spec=machine_spec, replica_count=1


### PR DESCRIPTION
<!-- Overview -->
The VertexAICustomTrainingJob class is missing the accelerator_count property, making it impossible to actually attach an accelerator to a custom job, due to the MachineSpec being invalid.

This PR adds the property and passes it to the `_build_job_spec` method to ensure it is passed along to Google properly.

### Example
```
vertex_ai_job = VertexAICustomTrainingJob(
    type="vertex-ai-custom-training-job",
    image=IMAGE_URI,
    credentials=GcpCredentials.load(GCP_CREDENTIALS_BLOCK_NAME),
    region="us-central1",
    network=NETWORK,
    service_account=SERVICE_ACCOUNT,
    machine_type="n1-standard-8",
    accelerator_type="NVIDIA_TESLA_T4",
    accelerator_count=1
)
```

### Screenshots
The documentation on this class is limited as is, these changes do not reduce their usability or accuracy.

### Checklist
- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [X] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [X] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
