### PR TITLE
Add BigQuery row to dictionary conversion in list

### DIFF
--- a/prefect_gcp/bigquery.py
+++ b/prefect_gcp/bigquery.py
@@ -79,7 +79,7 @@ async def bigquery_query(
             (e.g., dataset references will be rejected).
         project: The project to initialize the BigQuery Client with; if not
             provided, will default to the one inferred from your credentials.
-        result_transformer: Executes callable on end of function.
+        result_transformer: Function that can be passed to transform the result of a query before returning. The function will be passed the list of rows returned by BigQuery for the given query.
         location: Location of the dataset that will be queried.
 
     Returns:

--- a/prefect_gcp/bigquery.py
+++ b/prefect_gcp/bigquery.py
@@ -29,6 +29,7 @@ try:
     from google.cloud.bigquery.dbapi.cursor import Cursor
     from google.cloud.bigquery.table import Row
     from google.cloud.exceptions import NotFound
+    import pandas as pd
 except ModuleNotFoundError:
     pass
 
@@ -52,8 +53,9 @@ async def bigquery_query(
     to_dataframe: bool = False,
     job_config: Optional[dict] = None,
     project: Optional[str] = None,
+    rows_as_dict: Optional[bool] = False,
     location: str = "US",
-) -> List["Row"]:
+) -> Union[List["Row"], List[dict], pd.DataFrame]:
     """
     Runs a BigQuery query.
 
@@ -78,6 +80,7 @@ async def bigquery_query(
             (e.g., dataset references will be rejected).
         project: The project to initialize the BigQuery Client with; if not
             provided, will default to the one inferred from your credentials.
+        rows_as_dict: Converts bigquery client Row to python dictionaries in returned list.
         location: Location of the dataset that will be queried.
 
     Returns:
@@ -159,7 +162,10 @@ async def bigquery_query(
     if to_dataframe:
         return result.to_dataframe()
     else:
-        return list(result)
+        if rows_as_dict:
+            return [dict(row) for row in list(result)]
+        else:
+            return list(result)
 
 
 @task

--- a/prefect_gcp/bigquery.py
+++ b/prefect_gcp/bigquery.py
@@ -79,7 +79,7 @@ async def bigquery_query(
             (e.g., dataset references will be rejected).
         project: The project to initialize the BigQuery Client with; if not
             provided, will default to the one inferred from your credentials.
-        result_transformer: Converts bigquery client Row to python dictionaries in returned list.
+        result_transformer: Executes callable on end of function.
         location: Location of the dataset that will be queried.
 
     Returns:

--- a/prefect_gcp/bigquery.py
+++ b/prefect_gcp/bigquery.py
@@ -3,7 +3,7 @@
 import os
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, Callable
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from anyio import to_thread
 from prefect import get_run_logger, task

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -17,8 +17,9 @@ from prefect_gcp.bigquery import (
 
 
 @pytest.mark.parametrize("to_dataframe", [False, True])
+@pytest.mark.parametrize("result_transformer", [None, lambda _: ("test_transformer",)])
 @pytest.mark.parametrize("dry_run_max_bytes", [None, 5, 15])
-def test_bigquery_query(to_dataframe, dry_run_max_bytes, gcp_credentials):
+def test_bigquery_query(to_dataframe, result_transformer, dry_run_max_bytes, gcp_credentials):
     @flow
     def test_flow():
         return bigquery_query(
@@ -32,6 +33,7 @@ def test_bigquery_query(to_dataframe, dry_run_max_bytes, gcp_credentials):
             job_config={},
             project="project",
             location="US",
+            result_transformer=result_transformer,
         )
 
     if dry_run_max_bytes is not None and dry_run_max_bytes < 10:
@@ -42,7 +44,10 @@ def test_bigquery_query(to_dataframe, dry_run_max_bytes, gcp_credentials):
         if to_dataframe:
             assert result == "dataframe_query"
         else:
-            assert result == ["query"]
+            if result_transformer:
+                assert result == ("test_transformer",)
+            else:
+                assert result == ["query"]
 
 
 def test_bigquery_create_table(gcp_credentials):

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -19,7 +19,9 @@ from prefect_gcp.bigquery import (
 @pytest.mark.parametrize("to_dataframe", [False, True])
 @pytest.mark.parametrize("result_transformer", [None, lambda _: ("test_transformer",)])
 @pytest.mark.parametrize("dry_run_max_bytes", [None, 5, 15])
-def test_bigquery_query(to_dataframe, result_transformer, dry_run_max_bytes, gcp_credentials):
+def test_bigquery_query(
+    to_dataframe, result_transformer, dry_run_max_bytes, gcp_credentials
+):
     @flow
     def test_flow():
         return bigquery_query(


### PR DESCRIPTION
When using prefect-gcp you are forced to use pandas dataframe when using a task runner such as Ray or Dask. These task runners pickle the objects, but with large rows it can result in a maximum recursion depth exceeded exception, when you're using lists with Bigquery Row objects. This PR implements a optional row_as_dict argument. It also contains one minor typing hint fix. As the bigquery_query function also supports the return of a pandas dataframe.