### PR TITLE
adding boot_disk_type and boot_disk_size_gb

### DIFF
--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -78,7 +78,7 @@ try:
     )
     from google.cloud.aiplatform_v1.types.job_service import CancelCustomJobRequest
     from google.cloud.aiplatform_v1.types.job_state import JobState
-    from google.cloud.aiplatform_v1.types.machine_resources import MachineSpec
+    from google.cloud.aiplatform_v1.types.machine_resources import MachineSpec, DiskSpec
     from google.protobuf.duration_pb2 import Duration
 except ModuleNotFoundError:
     pass
@@ -140,6 +140,16 @@ class VertexAICustomTrainingJob(Infrastructure):
     )
     accelerator_count: Optional[int] = Field(
         default=None, description="The number of accelerators to attach to the machine."
+    )
+    boot_disk_type: str = Field(
+        default="pd-ssd",
+        title="Boot Disk Type",
+        description="The type of boot disk to attach to the machine."
+    )
+    boot_disk_size_gb: int = Field(
+        default="100",
+        title="Boot Disk Size",
+        description="The size of the boot disk to attach to the machine, in gigabytes."
     )
     maximum_run_time: datetime.timedelta = Field(
         default=datetime.timedelta(days=7), description="The maximum job running time."
@@ -223,9 +233,8 @@ class VertexAICustomTrainingJob(Infrastructure):
             accelerator_count=self.accelerator_count,
         )
         worker_pool_spec = WorkerPoolSpec(
-            container_spec=container_spec, machine_spec=machine_spec, replica_count=1
+            container_spec=container_spec, machine_spec=machine_spec, replica_count=1, disk_spec=DiskSpec(boot_disk_type=self.boot_disk_type, boot_disk_size_gb=self.boot_disk_size_gb)
         )
-
         # look for service account
         service_account = (
             self.service_account or self.gcp_credentials._service_account_email

--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -78,7 +78,7 @@ try:
     )
     from google.cloud.aiplatform_v1.types.job_service import CancelCustomJobRequest
     from google.cloud.aiplatform_v1.types.job_state import JobState
-    from google.cloud.aiplatform_v1.types.machine_resources import MachineSpec, DiskSpec
+    from google.cloud.aiplatform_v1.types.machine_resources import DiskSpec, MachineSpec
     from google.protobuf.duration_pb2 import Duration
 except ModuleNotFoundError:
     pass
@@ -144,12 +144,12 @@ class VertexAICustomTrainingJob(Infrastructure):
     boot_disk_type: str = Field(
         default="pd-ssd",
         title="Boot Disk Type",
-        description="The type of boot disk to attach to the machine."
+        description="The type of boot disk to attach to the machine.",
     )
     boot_disk_size_gb: int = Field(
-        default="100",
+        default=100,
         title="Boot Disk Size",
-        description="The size of the boot disk to attach to the machine, in gigabytes."
+        description="The size of the boot disk to attach to the machine, in gigabytes.",
     )
     maximum_run_time: datetime.timedelta = Field(
         default=datetime.timedelta(days=7), description="The maximum job running time."
@@ -233,7 +233,13 @@ class VertexAICustomTrainingJob(Infrastructure):
             accelerator_count=self.accelerator_count,
         )
         worker_pool_spec = WorkerPoolSpec(
-            container_spec=container_spec, machine_spec=machine_spec, replica_count=1, disk_spec=DiskSpec(boot_disk_type=self.boot_disk_type, boot_disk_size_gb=self.boot_disk_size_gb)
+            container_spec=container_spec,
+            machine_spec=machine_spec,
+            replica_count=1,
+            disk_spec=DiskSpec(
+                boot_disk_type=self.boot_disk_type,
+                boot_disk_size_gb=self.boot_disk_size_gb,
+            ),
         )
         # look for service account
         service_account = (

--- a/tests/test_aiplatform.py
+++ b/tests/test_aiplatform.py
@@ -46,6 +46,10 @@ class TestVertexAICustomTrainingJob:
                         machine_type: "n1-standard-4"
                     }
                     replica_count: 1
+                    disk_spec {
+                        boot_disk_type: "pd-ssd"
+                        boot_disk_size_gb: 100
+                    }
                 }
                 scheduling {
                 }


### PR DESCRIPTION
there params now will be standard on vertexai block, with defaults set to how they were implicitly in the code before.

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes https://github.com/PrefectHQ/prefect-gcp/issues/158

### Example

Now when you create **VertexAICustomTrainingJob** you can pass in the `boot_disk_type` (str) and `boot_disk_size_gb` (int) params.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #158" 
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
