### PR TITLE
Fix `list_folders` to keep dots in the middle of the paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Bug that `list_folders` method removes dot(`"."`)s in the middle of paths
 
 ### Security
 

--- a/prefect_gcp/cloud_storage.py
+++ b/prefect_gcp/cloud_storage.py
@@ -912,11 +912,9 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
 
         blobs = await self.list_blobs(folder)
         # gets all folders with full path
-        folders = {
-            str(PurePosixPath(blob.name).parent).replace(".", "") for blob in blobs
-        }
+        folders = {str(PurePosixPath(blob.name).parent) for blob in blobs}
 
-        return list(folders)
+        return [folder for folder in folders if folder != "."]
 
     @sync_compatible
     async def download_object_to_path(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,14 @@ class CloudStorageClient:
         blob_directory = Blob(name="directory/")
         nested_blob_obj = Blob(name="base_folder/nested_blob.txt")
         double_nested_blob_obj = Blob(name="base_folder/sub_folder/nested_blob.txt")
-        blobs = [blob_obj, blob_directory, nested_blob_obj, double_nested_blob_obj]
+        dotted_folder_blob_obj = Blob(name="dotted.folder/nested_blob.txt")
+        blobs = [
+            blob_obj,
+            blob_directory,
+            nested_blob_obj,
+            double_nested_blob_obj,
+            dotted_folder_blob_obj,
+        ]
         if prefix:
             blobs = [blob for blob in blobs if blob.name.startswith(prefix)]
         return blobs

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -235,24 +235,28 @@ class TestGcsBucket:
         )
 
     def test_list_folders_root_folder(self, gcs_bucket_no_bucket_folder):
-        blobs = gcs_bucket_no_bucket_folder.list_folders()
-        assert len(blobs) == 3
-        assert set(blobs) == {"base_folder", "base_folder/sub_folder", "dotted.folder"}
+        folders = gcs_bucket_no_bucket_folder.list_folders()
+        assert len(folders) == 3
+        assert set(folders) == {
+            "base_folder",
+            "base_folder/sub_folder",
+            "dotted.folder",
+        }
 
     def test_list_folders_with_root_only(self, gcs_bucket_with_bucket_folder):
-        blobs = gcs_bucket_with_bucket_folder.list_folders()
-        assert len(blobs) == 2
-        assert set(blobs) == {"base_folder", "base_folder/sub_folder"}
+        folders = gcs_bucket_with_bucket_folder.list_folders()
+        assert len(folders) == 2
+        assert set(folders) == {"base_folder", "base_folder/sub_folder"}
 
     def test_list_folders_with_sub_folders(self, gcs_bucket_with_bucket_folder):
-        blobs = gcs_bucket_with_bucket_folder.list_folders("sub_folder/")
-        assert len(blobs) == 1
-        assert blobs[0] == "base_folder/sub_folder"
+        folders = gcs_bucket_with_bucket_folder.list_folders("sub_folder/")
+        assert len(folders) == 1
+        assert folders[0] == "base_folder/sub_folder"
 
     def test_list_folders_with_dotted_folders(self, gcs_bucket_no_bucket_folder):
-        blobs = gcs_bucket_no_bucket_folder.list_folders("dotted.folder/")
-        assert len(blobs) == 1
-        assert blobs[0] == "dotted.folder"
+        folders = gcs_bucket_no_bucket_folder.list_folders("dotted.folder/")
+        assert len(folders) == 1
+        assert folders[0] == "dotted.folder"
 
     def test_list_blobs(self, gcs_bucket_no_bucket_folder):
         blobs = gcs_bucket_no_bucket_folder.list_blobs(folder="base_folder/")

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -168,7 +168,7 @@ class TestGcsBucket:
 
         # blob.txt, base_folder/nested_blob.txt, base_folder/sub_folder/nested_blob.txt
         if not prefix:
-            assert len(actual) == 3
+            assert len(actual) == 4
         # base_folder/sub_folder/nested_blob.txt
         elif prefix == "base_folder/sub_folder":
             assert len(actual) == 1
@@ -234,6 +234,11 @@ class TestGcsBucket:
             }
         )
 
+    def test_list_folders_root_folder(self, gcs_bucket_no_bucket_folder):
+        blobs = gcs_bucket_no_bucket_folder.list_folders()
+        assert len(blobs) == 3
+        assert set(blobs) == {"base_folder", "base_folder/sub_folder", "dotted.folder"}
+
     def test_list_folders_with_root_only(self, gcs_bucket_with_bucket_folder):
         blobs = gcs_bucket_with_bucket_folder.list_folders()
         assert len(blobs) == 2
@@ -243,6 +248,11 @@ class TestGcsBucket:
         blobs = gcs_bucket_with_bucket_folder.list_folders("sub_folder/")
         assert len(blobs) == 1
         assert blobs[0] == "base_folder/sub_folder"
+
+    def test_list_folders_with_dotted_folders(self, gcs_bucket_no_bucket_folder):
+        blobs = gcs_bucket_no_bucket_folder.list_folders("dotted.folder/")
+        assert len(blobs) == 1
+        assert blobs[0] == "dotted.folder"
 
     def test_list_blobs(self, gcs_bucket_no_bucket_folder):
         blobs = gcs_bucket_no_bucket_folder.list_blobs(folder="base_folder/")
@@ -264,10 +274,11 @@ class TestGcsBucket:
 
     def test_list_blobs_root_folder(self, gcs_bucket_no_bucket_folder):
         blobs = gcs_bucket_no_bucket_folder.list_blobs(folder="")
-        assert len(blobs) == 3
+        assert len(blobs) == 4
         assert blobs[0].name == "blob.txt"
         assert blobs[1].name == "base_folder/nested_blob.txt"
         assert blobs[2].name == "base_folder/sub_folder/nested_blob.txt"
+        assert blobs[3].name == "dotted.folder/nested_blob.txt"
 
     def test_download_object_to_path_default(
         self, gcs_bucket_with_bucket_folder, tmp_path


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
There was a bug in the `GcsBucket.list_folders` method, that all the dots(`"."`) in the folder paths were gone in its returned values.
That occurred by `.replace(".", "")` after getting paths. Maybe it is because there is unwanted `"."` if there is a file in the current position (refers to #121). We can use a simple filter, instead.

There was no tests with example blob under a folder named with dots. And there wasn't even the test for `list_folders` for the root. So I added along with the fix.

I am not sure including `""` as one of the result is wanted instead of `"."`. I thought it can be just omitted.

### Example
`bucket` is a `GcsBucket` instance that points a bucket with blobs with paths:
- `"blob.txt"`
- `"base_folder/nested_blob.txt"`
- `"dotted.folder/nested_blob.txt"`
#### Before
```
bucket.list_folders()  # ["", "base_folder", "dottedfolder"]
```

#### After
```
bucket.list_folders()  # ["base_folder", "dotted.folder"]
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
