### PR TITLE
fix: Bug that `put_directory` method in `cloud_storage.py`(GcsBucket) do not upload files that in directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-- Bug that `list_folders` method removes dot(`"."`)s in the middle of paths
 - Bug that `put_directory` method in `cloud_storage.py`(GcsBucket) do not upload files that in directory
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bug that `list_folders` method removes dot(`"."`)s in the middle of paths
+- Bug that `put_directory` method in `cloud_storage.py`(GcsBucket) do not upload files that in directory
 
 ### Security
 

--- a/prefect_gcp/cloud_storage.py
+++ b/prefect_gcp/cloud_storage.py
@@ -715,7 +715,7 @@ class GcsBucket(WritableDeploymentStorage, WritableFileSystem, ObjectStorageBloc
         for local_file_path in Path(local_path).rglob("*"):
             if (
                 included_files is not None
-                and local_file_path.name not in included_files
+                and str(local_file_path.relative_to(local_path)) not in included_files
             ):
                 continue
             elif not local_file_path.is_dir():

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -188,11 +188,14 @@ class TestGcsBucket:
         (local_path / "cab.txt").write_text("cab")
         (local_path / "some_dir").mkdir()
 
+        (local_path / "some_dir/text_file_in_dir.txt").write_text("hello")
+        (local_path / "some_dir/html_file_in_dir.html").write_text("<html>hello</html>")
+
         expected = 2
         if ignore:
             ignore_file = tmp_path / "ignore.txt"
             ignore_file.write_text("*.html")
-            expected -= 1
+            expected -= 2
         else:
             ignore_file = None
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
pre-commit test
![pass](https://github.com/PrefectHQ/prefect-gcp/assets/736998/da902ba3-1025-4ba1-b8f7-96192ea2c4d0)

docs not change

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
