### PR TITLE
Persist Labels to Vertex AI Custom Job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.4.6
+
+Not yet released
+
+### Changed
+
+- Vertex AI CustomJob sets labels specified by Prefect Agent when Deployment triggered on infrastructure.
+
 ## 0.4.5
 
 Released July 20th, 2023.

--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -217,7 +217,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         For example, the Prefect provided key of prefect.io/flow-name -> prefect-io_flow-name
         """
         compatible_labels = {}
-        for key, val in self.labels:
+        for key, val in self.labels.items():
             new_key = slugify(key, lowercase=True, replacements=[('/', '-'), ('.', '_')], max_length=63)
             compatible_labels[new_key] = slugify(val, lowercase=True, replacements=[('/', '-'), ('.', '_')], max_length=63)
         return compatible_labels

--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -53,8 +53,8 @@ Examples:
 """
 
 import datetime
-import time
 import re
+import time
 from typing import Dict, List, Optional, Tuple
 from uuid import uuid4
 
@@ -88,8 +88,7 @@ except ModuleNotFoundError:
 
 from prefect_gcp.credentials import GcpCredentials
 
-
-_DISALLOWED_GCP_LABEL_CHARACTERS = re.compile(r'[^-a-zA-Z0-9_]+')
+_DISALLOWED_GCP_LABEL_CHARACTERS = re.compile(r"[^-a-zA-Z0-9_]+")
 
 
 class VertexAICustomTrainingJobResult(InfrastructureResult):
@@ -217,7 +216,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         Ensures labels are compatible with GCP label requirements.
         https://cloud.google.com/resource-manager/docs/creating-managing-labels
 
-        For example, the Prefect provided key of prefect.io/flow-name -> prefect-io_flow-name
+        Ex: the Prefect provided key of prefect.io/flow-name -> prefect-io_flow-name
         """
         compatible_labels = {}
         for key, val in self.labels.items():
@@ -226,14 +225,14 @@ class VertexAICustomTrainingJob(Infrastructure):
                 lowercase=True,
                 replacements=[("/", "_"), (".", "-")],
                 max_length=63,
-                regex_pattern=_DISALLOWED_GCP_LABEL_CHARACTERS
+                regex_pattern=_DISALLOWED_GCP_LABEL_CHARACTERS,
             )
             compatible_labels[new_key] = slugify(
                 val,
                 lowercase=True,
                 replacements=[("/", "_"), (".", "-")],
                 max_length=63,
-                regex_pattern=_DISALLOWED_GCP_LABEL_CHARACTERS
+                regex_pattern=_DISALLOWED_GCP_LABEL_CHARACTERS,
             )
         return compatible_labels
 

--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -273,7 +273,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         Builds a custom job and begins running it.
         """
         # create custom job
-        custom_job = CustomJob(display_name=self.job_name, job_spec=job_spec)
+        custom_job = CustomJob(display_name=self.job_name, job_spec=job_spec, labels=self.labels)
 
         # run job
         self.logger.info(

--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -211,7 +211,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         job_name = f"{repo_name}-{unique_suffix}"
         return job_name
 
-    def _ensure_compatible_labels(self) -> Dict[str, str]:
+    def _get_compatible_labels(self) -> Dict[str, str]:
         """
         Ensures labels are compatible with GCP label requirements.
         https://cloud.google.com/resource-manager/docs/creating-managing-labels
@@ -242,7 +242,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         custom_job = CustomJob(
             display_name=self.job_name,
             job_spec=job_spec,
-            labels=self._ensure_compatible_labels(),
+            labels=self._get_compatible_labels(),
         )
         return str(custom_job)  # outputs a json string
 
@@ -309,7 +309,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         custom_job = CustomJob(
             display_name=self.job_name,
             job_spec=job_spec,
-            labels=self._ensure_compatible_labels(),
+            labels=self._get_compatible_labels(),
         )
 
         # run job

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ prefect>=2.10.17
 google-api-python-client>=2.20.0
 google-cloud-storage>=2.0.0
 tenacity>=8.0.0
+python-slugify>=8.0.0

--- a/tests/test_aiplatform.py
+++ b/tests/test_aiplatform.py
@@ -20,7 +20,7 @@ class TestVertexAICustomTrainingJob:
             region="us-east1",
             image="us-docker.pkg.dev/cloudrun/container/job:latest",
             gcp_credentials=gcp_credentials,
-            labels={"prefect.io/flow-name": "hungry-hippo"}
+            labels={"prefect.io/flow-name": "hungry-hippo"},
         )
 
     # TODO: Improve test resiliency to changes in str output

--- a/tests/test_aiplatform.py
+++ b/tests/test_aiplatform.py
@@ -20,6 +20,7 @@ class TestVertexAICustomTrainingJob:
             region="us-east1",
             image="us-docker.pkg.dev/cloudrun/container/job:latest",
             gcp_credentials=gcp_credentials,
+            labels={"prefect.io/flow-name": "hungry-hippo"}
         )
 
     # TODO: Improve test resiliency to changes in str output
@@ -55,6 +56,10 @@ class TestVertexAICustomTrainingJob:
                 scheduling {
                 }
                 service_account: "my_service_account_email"
+            }
+            labels {
+                key: "prefect-io_flow-name"
+                value: "hungry-hippo"
             }
         """.strip().splitlines()
 


### PR DESCRIPTION
When the Prefect Agent fetches the `Infrastructure` from a `Deployment` to execute a `FlowRun` for a particular `Flow`, a set of labels is computed and set in the associated `Infrastructure` for a particular deployment.

https://github.com/PrefectHQ/prefect/blob/e530ca3285764accaef9360ba17e84610cb7e0cf/src/prefect/infrastructure/base.py#L88-L119

It would be helpful if these labels can be persisted to the underlying Vertex AI Custom Job resource.   This would enable effective querying for particular jobs that match a given condition (e.g. all the CustomJobs associated with a particular `FlowRun`).  Otherwise especially in environments where many `CustomJobs` are run, it's cumbersome to make the association and attribution.

Closes #200 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [✅  ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [ ✅ ] Includes tests or only affects documentation.
- [✅  ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ✅ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ✅ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
