### PR TITLE
Fixing empty logging in list_folders and list_blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `list_folders` and `list_blobs` now logging bucket name and bucket path - [#184](https://github.com/PrefectHQ/prefect-gcp/pull/214)
+
 ### Security
 
 ## 0.4.7


### PR DESCRIPTION
## Fix: Log of `list_folders` and `list_blobs` now displays bucket name and path

Closes #184.

When calling `list_folders` or `list_blobs` on a `GcsBucket` the log message always displayed `bucket_path`, a result of `_join_bucket_folder`.
If we are in the root directory however, `_join_bucket_folder` returns `None`.
If we hand a value for `folder` we receive the joined path.

### Changes made
Depending on wether `_join_bucket_folder` returns `None`, which would mean we are listing from the root directory, we conditionally log a message containing the current `bucket_path` or just `self.bucket`.

I did not write tests for the log messages. If its needed, I will happily do so.

**This will have to be discussed and I am happy to receive some guidance on this:** 
There exists a warning in the  doc of `_join_bucket_folder` to be careful to not call it twice in nested method calls. 
With my implementation it is now called with the `folder` parameter in `list_folders` and `list_blobs`.
Since `bucket_path` is not used in any other way in `list_folders` we should be fine.
However, I see that this might lead to some bug down the road. 
Thats why I wrote a warning comment. 

This seemed to be the best approach to me, since other methods would have involved more conditional checking of `self.bucket_folder`/`folder` in `list_folders` and combining them in some way in the message,
which seemed to be too bloated just for a more sophisticated log message.
I also thought about `_resolve_path`, but it would lead to the same dangerous problem down the road and `_join_bucket_folder` has a condition to check, if the method got called twice.

If you prefer any of the mentioned methods or have a different idea, I am happy to implement it.

### Example
When running this code:
```
from prefect_gcp import GcsBucket

bucket = GcsBucket(
    bucket="my-bucket",
)

bucket.list_folders()
```

The log output is:
```
08:35:21.362 | INFO    | prefect.GcsBucket - Listing folders in bucket 'my-bucket'.
08:35:21.677 | INFO    | prefect.GcsBucket - Listing blobs in bucket 'my-bucket'.
```

When running this code:
```
from prefect_gcp import GcsBucket

bucket = GcsBucket(
    bucket="my-bucket",
    bucket_folder="my-folder"
)

bucket.list_folders()
```

The log output is:
```
08:37:58.936 | INFO    | prefect.GcsBucket - Listing folders in 'my-folder' in bucket 'my-bucket'.
08:37:59.287 | INFO    | prefect.GcsBucket - Listing blobs in folder 'my-folder' in bucket 'my-bucket'.
```

When running `test_list_folders_with_subfolders` the log output is:
```
08:40:48.379 | INFO | prefect.GcsBucket - Listing folders in 'base_folder/sub_folder' in bucket 'bucket'.

08:40:48.382 | INFO | prefect.GcsBucket - Listing blobs in folder 'base_folder/sub_folder' in bucket 'bucket'.
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
