### PR TITLE
Get project id from `google.auth.default()` in empty `GcpCredentials` block if quota project is `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `list_folders` and `list_blobs` now logging bucket name and bucket path - [#184](https://github.com/PrefectHQ/prefect-gcp/pull/214)
-- Fix empty `GcpCredentials` not inferring the GCP project upon initialization when running on Compute Engine, Cloud Run, and App Engine [#219](https://github.com/PrefectHQ/prefect-gcp/pull/219)
+- Fix empty `GcpCredentials` not inferring the GCP project upon initialization when running on Compute Engine, Cloud Run, and App Engine - [#219](https://github.com/PrefectHQ/prefect-gcp/pull/219)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `list_folders` and `list_blobs` now logging bucket name and bucket path - [#184](https://github.com/PrefectHQ/prefect-gcp/pull/214)
-- Fix empty `GcpCredentials` not inferring the GCP project upon initialization when running on Compute Engine, Cloud Run, and App Engine
+- Fix empty `GcpCredentials` not inferring the GCP project upon initialization when running on Compute Engine, Cloud Run, and App Engine [#219](https://github.com/PrefectHQ/prefect-gcp/pull/219)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `list_folders` and `list_blobs` now logging bucket name and bucket path - [#184](https://github.com/PrefectHQ/prefect-gcp/pull/214)
+- Fix empty `GcpCredentials` not inferring the GCP project upon initialization when running on Compute Engine, Cloud Run, and App Engine
 
 ### Security
 

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -164,8 +164,12 @@ class GcpCredentials(CredentialsBlock):
         if self.project is None:
             if self.service_account_info or self.service_account_file:
                 credentials_project = credentials.project_id
-            else:  # google.auth.default using gcloud auth application-default login
+            # google.auth.default using gcloud auth application-default login
+            elif credentials.quota_project_id:
                 credentials_project = credentials.quota_project_id
+            # compute-assigned service account via GCP metadata server
+            else:
+                _, credentials_project = google.auth.default()
             self.project = credentials_project
 
         if hasattr(credentials, "service_account_email"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,20 @@ def google_auth(monkeypatch):
 
 
 @pytest.fixture
+def google_auth_no_quota_project(monkeypatch):
+    google_auth_mock = MagicMock()
+    default_credentials_mock = MagicMock(
+        client_id="my_client_id", quota_project_id=None
+    )
+    google_auth_mock.default.side_effect = lambda *args, **kwargs: (
+        default_credentials_mock,
+        "my_project",
+    )
+    monkeypatch.setattr("google.auth", google_auth_mock)
+    return google_auth_mock
+
+
+@pytest.fixture
 def oauth2_credentials(monkeypatch):
     CredentialsMock = MagicMock()
     CredentialsMock.from_service_account_info.side_effect = (

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -108,6 +108,13 @@ def test_block_initialization_gcloud_cli(google_auth, oauth2_credentials):
     assert gcp_credentials.project == "my_project"
 
 
+def test_block_initialization_metadata_server(
+    google_auth_no_quota_project, oauth2_credentials
+):
+    gcp_credentials = GcpCredentials()
+    assert gcp_credentials.project == "my_project"
+
+
 @pytest.mark.parametrize("override_project", [None, "override_project"])
 def test_get_cloud_storage_client(
     override_project, service_account_info, oauth2_credentials, storage_client


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Adds a check to `GcpCredentials` block initialization to acquire the GCP project id from `google.auth.default()` if no `quota_project_id` exists. This scenario arises when initializing an empty block on compute in Cloud Run, Compute Engine, or App Engine in which `gcloud auth application-default login` has not been run. Enables Cloud Run workers on compute with an attached service account and the correct roles to start Cloud Run jobs without requiring a completed GCP Credentials block to be added to the connected work pool.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
