### PR TITLE
Add `service_account_name` to Cloud Run V2 default template and variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `service_account_name` to Cloud Run v2 default template and variables - [#231](https://github.com/PrefectHQ/prefect-gcp/pull/231)
+
 ### Changed
 
 ### Deprecated
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Released November 29th, 2023.
 
 ### Changed
+
 - Fix display name for Google Cloud Run v2 worker / work pool - [#229](https://github.com/PrefectHQ/prefect-gcp/pull/229)
 - Removed credentials block creation step from the google cloud run worker guide - [#228](https://github.com/PrefectHQ/prefect-gcp/pull/228)
 
@@ -91,13 +94,14 @@ Released September 5th, 2023.
 
 ### Changed
 
-- Persist Labels to Vertex AI Custom Job - [#198](https://github.com/PrefectHQ/prefect-gcp/pull/208) 
+- Persist Labels to Vertex AI Custom Job - [#198](https://github.com/PrefectHQ/prefect-gcp/pull/208)
 
 ## 0.4.5
 
 Released July 20th, 2023.
 
 ### Changed
+
 - Promoted workers to GA, removed beta disclaimers
 
 ## 0.4.4
@@ -123,7 +127,7 @@ Released June 15th, 2023.
 
 ### Fixed
 
-- Bug that `list_folders` method removes dot(`"."`)s in the middle of paths 
+- Bug that `list_folders` method removes dot(`"."`)s in the middle of paths
 
 ## 0.4.2
 
@@ -143,6 +147,7 @@ Released on April 20th, 2023.
 ### Added
 
 - `CloudRunWorker` for executing Prefect flows via Google Cloud Run - [#172](https://github.com/PrefectHQ/prefect-gcp/pull/172)
+
 ### Fixed
 
 - Fix `CloudRunJob` with VPC Connector usage. - [#170](https://github.com/PrefectHQ/prefect-gcp/pull/170)
@@ -151,13 +156,13 @@ Released on April 20th, 2023.
 
 Released on April 6th, 2023.
 
-### Added 
+### Added
 
 - `pull_project_from_gcs` and `push_project_to_gcs` steps - [#167](https://github.com/PrefectHQ/prefect-gcp/pull/167)
 
 ### Fixed
 
-- `upload_from_dataframe` docstring - [#162](https://github.com/PrefectHQ/prefect-gcp/pull/162) 
+- `upload_from_dataframe` docstring - [#162](https://github.com/PrefectHQ/prefect-gcp/pull/162)
 - `upload_from_dataframe` file extensions for compressed parquet ('.snappy.parquet', '.gz.parquet') - [#166](https://github.com/PrefectHQ/prefect-gcp/pull/166)
 
 ## 0.3.0
@@ -295,6 +300,7 @@ Released on September 28th, 2022.
 Released on September 19th, 2022.
 
 ### Added
+
 - `CloudRunJob` infrastructure block - [#48](https://github.com/PrefectHQ/prefect-gcp/pull/48)
 - `GcsBucket` block - [#41](https://github.com/PrefectHQ/prefect-gcp/pull/41)
 - `external_config` keyword argument in `bigquery_create_table` task - [#53](https://github.com/PrefectHQ/prefect-gcp/pull/53)
@@ -302,6 +308,7 @@ Released on September 19th, 2022.
 - `**kwargs` for all tasks in the module `cloud_storage.py` - [#47](https://github.com/PrefectHQ/prefect-gcp/pull/47)
 
 ### Changed
+
 - Made `schema` keyword argument optional in `bigquery_create_table` task, thus the position of the keyword changed - [#53](https://github.com/PrefectHQ/prefect-gcp/pull/53)
 - Allowed `~` character to be used in the path for service account file - [#38](https://github.com/PrefectHQ/prefect-gcp/pull/38)
 
@@ -310,15 +317,19 @@ Released on September 19th, 2022.
 - `ValidationError` using `GcpCredentials.service_account_info` in `prefect-dbt` - [#44](https://github.com/PrefectHQ/prefect-gcp/pull/44)
 
 ## 0.1.3
+
 Released on July 22nd, 2022.
 
 ### Added
+
 - Added setup.py entry point - [#35](https://github.com/PrefectHQ/prefect-gcp/pull/35)
 
 ## 0.1.2
+
 Released on July 22nd, 2022.
 
 ### Changed
+
 - Updated tests to be compatible with core Prefect library (v2.0b9) and bumped required version - [#30](https://github.com/PrefectHQ/prefect-gcp/pull/30)
 - Converted GcpCredentials into a Block - [#31](https://github.com/PrefectHQ/prefect-gcp/pull/31).
 

--- a/prefect_gcp/workers/cloud_run_v2.py
+++ b/prefect_gcp/workers/cloud_run_v2.py
@@ -369,9 +369,9 @@ class CloudRunWorkerV2Variables(BaseVariables):
         default=None,
         title="Service Account Name",
         description=(
-           "The name of the service account to use for the task execution "
-           "of Cloud Run Job. By default Cloud Run jobs run as the default "
-           "Compute Engine Service Account."
+            "The name of the service account to use for the task execution "
+            "of Cloud Run Job. By default Cloud Run jobs run as the default "
+            "Compute Engine Service Account."
         ),
         example="service-account@example.iam.gserviceaccount.com",
     )

--- a/prefect_gcp/workers/cloud_run_v2.py
+++ b/prefect_gcp/workers/cloud_run_v2.py
@@ -368,9 +368,11 @@ class CloudRunWorkerV2Variables(BaseVariables):
     service_account_name: Optional[str] = Field(
         default=None,
         title="Service Account Name",
-        description="The name of the service account to use for the task execution "
-        "of Cloud Run Job. By default Cloud Run jobs run as the default "
-        "Compute Engine Service Account. ",
+        description=(
+           "The name of the service account to use for the task execution "
+           "of Cloud Run Job. By default Cloud Run jobs run as the default "
+           "Compute Engine Service Account."
+        ),
         example="service-account@example.iam.gserviceaccount.com",
     )
 

--- a/prefect_gcp/workers/cloud_run_v2.py
+++ b/prefect_gcp/workers/cloud_run_v2.py
@@ -49,6 +49,7 @@ def _get_default_job_body_template() -> Dict[str, Any]:
         "launchStage": "{{ launch_stage }}",
         "template": {
             "template": {
+                "serviceAccount": "{{ service_account_name }}",
                 "maxRetries": "{{ max_retries }}",
                 "timeout": "{{ timeout }}",
                 "containers": [
@@ -363,6 +364,14 @@ class CloudRunWorkerV2Variables(BaseVariables):
         default=None,
         title="VPC Connector Name",
         description="The name of the VPC connector to use for the Cloud Run job.",
+    )
+    service_account_name: Optional[str] = Field(
+        default=None,
+        title="Service Account Name",
+        description="The name of the service account to use for the task execution "
+        "of Cloud Run Job. By default Cloud Run jobs run as the default "
+        "Compute Engine Service Account. ",
+        example="service-account@example.iam.gserviceaccount.com",
     )
 
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Adds support for the `serviceAccount` field in the Cloud Run V2 API Job template via the `service_account_name` variable to improve default template parity with the V1 work pool.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
