### PR TITLE
Japerry911/fix/cloud run v2 worker def cmd switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Modified default command logic in `CloudRunWorkerJobV2Configuration` to utilize the `BaseJobConfiguration._base_flow_run_command` method.
+
 ### Security
 
 ## 0.5.4

--- a/prefect_gcp/workers/cloud_run_v2.py
+++ b/prefect_gcp/workers/cloud_run_v2.py
@@ -209,11 +209,9 @@ class CloudRunWorkerJobV2Configuration(BaseJobConfiguration):
         command = self.job_body["template"]["template"]["containers"][0].get("command")
 
         if command is None:
-            self.job_body["template"]["template"]["containers"][0]["command"] = [
-                "python",
-                "-m",
-                "prefect.engine",
-            ]
+            self.job_body["template"]["template"]["containers"][0][
+                "command"
+            ] = shlex.split(self._base_flow_run_command())
         elif isinstance(command, str):
             self.job_body["template"]["template"]["containers"][0][
                 "command"

--- a/tests/test_cloud_run_worker_v2.py
+++ b/tests/test_cloud_run_worker_v2.py
@@ -84,7 +84,7 @@ class TestCloudRunWorkerJobV2Configuration:
 
         assert cloud_run_worker_v2_job_config.job_body["template"]["template"][
             "containers"
-        ][0]["command"] == ["python", "-m", "prefect.engine"]
+        ][0]["command"] == ["prefect", "flow-run", "execute"]
 
     def test_format_args_if_present(self, cloud_run_worker_v2_job_config):
         cloud_run_worker_v2_job_config._format_args_if_present()


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Update the Cloud Run v2 Worker, so it utilizes `BaseJobConfiguration._base_flow_run_command` for default command logic.

Closes #232

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
```python
self.job_body["template"]["template"]["containers"][0][
     "command"
] = shlex.split(self._base_flow_run_command())
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
