### PR TITLE
Add the ability to publish `CloudRun` blocks as work pools

### DIFF
--- a/prefect_gcp/cloud_run.py
+++ b/prefect_gcp/cloud_run.py
@@ -348,9 +348,17 @@ class CloudRunJob(Infrastructure):
         return values
 
     def get_corresponding_worker_type(self) -> str:
+        """Return the corresponding worker type for this infrastructure block."""
         return "cloud-run"
 
     async def generate_work_pool_base_job_template(self) -> dict:
+        """
+        Generate a base job template for a cloud-run work pool with the same
+        configuration as this block.
+
+        Returns:
+            - dict: a base job template for a cloud-run work pool
+        """
         base_job_template = await get_default_base_job_template_for_infrastructure_type(
             self.get_corresponding_worker_type(),
         )

--- a/prefect_gcp/cloud_run.py
+++ b/prefect_gcp/cloud_run.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import time
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
@@ -50,6 +51,10 @@ if PYDANTIC_VERSION.startswith("2."):
 else:
     from pydantic import BaseModel, Field, root_validator, validator
 
+from prefect.blocks.core import BlockNotSavedError
+from prefect.workers.utilities import (
+    get_default_base_job_template_for_infrastructure_type,
+)
 from typing_extensions import Literal
 
 from prefect_gcp.credentials import GcpCredentials
@@ -341,6 +346,73 @@ class CloudRunJob(Infrastructure):
                 " value other than the default memory value."
             )
         return values
+
+    def get_corresponding_worker_type(self) -> str:
+        return "cloud-run"
+
+    async def generate_work_pool_base_job_template(self) -> dict:
+        base_job_template = await get_default_base_job_template_for_infrastructure_type(
+            self.get_corresponding_worker_type(),
+        )
+        assert (
+            base_job_template is not None
+        ), "Failed to generate default base job template for Cloud Run worker."
+        for key, value in self.dict(exclude_unset=True, exclude_defaults=True).items():
+            if key == "command":
+                base_job_template["variables"]["properties"]["command"][
+                    "default"
+                ] = shlex.join(value)
+            elif key in [
+                "type",
+                "block_type_slug",
+                "_block_document_id",
+                "_block_document_name",
+                "_is_anonymous",
+                "memory_unit",
+            ]:
+                continue
+            elif key == "credentials":
+                if not self.credentials._block_document_id:
+                    raise BlockNotSavedError(
+                        "It looks like you are trying to use a block that"
+                        " has not been saved. Please call `.save` on your block"
+                        " before publishing it as a work pool."
+                    )
+                base_job_template["variables"]["properties"]["credentials"][
+                    "default"
+                ] = {
+                    "$ref": {
+                        "block_document_id": str(self.credentials._block_document_id)
+                    }
+                }
+            elif key == "memory" and self.memory_string:
+                base_job_template["variables"]["properties"]["memory"][
+                    "default"
+                ] = self.memory_string
+            elif key == "cpu" and self.cpu is not None:
+                base_job_template["variables"]["properties"]["cpu"][
+                    "default"
+                ] = f"{self.cpu * 1000}m"
+            elif key == "args":
+                # Not a default variable, but we can add it to the template
+                base_job_template["variables"]["properties"]["args"] = {
+                    "title": "Arguments",
+                    "type": "string",
+                    "description": "Arguments to be passed to your Cloud Run Job's entrypoint command.",  # noqa
+                    "default": value,
+                }
+                base_job_template["job_configuration"]["job_body"]["spec"]["template"][
+                    "spec"
+                ]["template"]["spec"]["containers"][0]["args"] = "{{ args }}"
+            elif key in base_job_template["variables"]["properties"]:
+                base_job_template["variables"]["properties"][key]["default"] = value
+            else:
+                self.logger.warning(
+                    f"Variable {key!r} is not supported by Cloud Run work pools."
+                    " Skipping."
+                )
+
+        return base_job_template
 
     def _create_job_error(self, exc):
         """Provides a nicer error for 404s when trying to create a Cloud Run Job."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prefect>=2.13.5
+prefect>=2.14.10
 google-api-python-client>=2.20.0
 google-cloud-storage>=2.0.0
 tenacity>=8.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from google.api_core.exceptions import NotFound as ApiCoreNotFound
 from google.cloud.aiplatform_v1.types.job_state import JobState
 from google.cloud.exceptions import NotFound
+from prefect.settings import PREFECT_LOGGING_TO_API_ENABLED, temporary_settings
 from prefect.testing.utilities import prefect_test_harness
 
 from prefect_gcp.credentials import GcpCredentials
@@ -14,6 +15,12 @@ from prefect_gcp.credentials import GcpCredentials
 @pytest.fixture(scope="session", autouse=True)
 def prefect_db():
     with prefect_test_harness():
+        yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_logging():
+    with temporary_settings({PREFECT_LOGGING_TO_API_ENABLED: False}):
         yield
 
 

--- a/tests/test_cloud_run.py
+++ b/tests/test_cloud_run.py
@@ -829,8 +829,10 @@ def default_base_job_template():
 
 
 @pytest.fixture
-async def credentials_block():
-    credentials_block = GcpCredentials()
+async def credentials_block(service_account_info):
+    credentials_block = GcpCredentials(
+        service_account_info=service_account_info, project="my-project"
+    )
     await credentials_block.save("test-for-publish", overwrite=True)
     return credentials_block
 

--- a/tests/test_cloud_run.py
+++ b/tests/test_cloud_run.py
@@ -1,7 +1,10 @@
+from copy import deepcopy
 from unittest.mock import Mock
 
 import anyio
 from pydantic import VERSION as PYDANTIC_VERSION
+
+from prefect_gcp.workers.cloud_run import CloudRunWorker
 
 if PYDANTIC_VERSION.startswith("2."):
     import pydantic.v1 as pydantic
@@ -14,6 +17,7 @@ from prefect.exceptions import InfrastructureNotFound
 from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
+    PREFECT_LOGGING_TO_API_ENABLED,
     PREFECT_PROFILES_PATH,
     temporary_settings,
 )
@@ -427,7 +431,8 @@ class TestCloudRunJobContainerSettings:
                 PREFECT_API_KEY: "Dog",
                 PREFECT_API_URL: "Puppy",
                 PREFECT_PROFILES_PATH: "Woof",
-            }
+            },
+            restore_defaults={PREFECT_LOGGING_TO_API_ENABLED},
         ):
             result = cloud_run_job._add_container_settings(base_setting)
             assert remove_server_url_from_env(result["env"]) == [
@@ -445,7 +450,8 @@ class TestCloudRunJobContainerSettings:
                 PREFECT_API_KEY: "Dog",
                 PREFECT_API_URL: "Puppy",
                 PREFECT_PROFILES_PATH: "Woof",
-            }
+            },
+            restore_defaults={PREFECT_LOGGING_TO_API_ENABLED},
         ):
             result = cloud_run_job._add_container_settings(base_setting)
             assert remove_server_url_from_env(result["env"]) == [
@@ -468,7 +474,8 @@ class TestCloudRunJobContainerSettings:
                 PREFECT_API_KEY: "Dog",
                 PREFECT_API_URL: "Puppy",
                 PREFECT_PROFILES_PATH: "Woof",
-            }
+            },
+            restore_defaults={PREFECT_LOGGING_TO_API_ENABLED},
         ):
             result = cloud_run_job._add_container_settings(base_setting)
             assert remove_server_url_from_env(result["env"]) == [
@@ -814,3 +821,119 @@ class TestCloudRunJobRun:
                 break
         else:
             raise AssertionError("Expected message not found.")
+
+
+@pytest.fixture
+def default_base_job_template():
+    return deepcopy(CloudRunWorker.get_default_base_job_template())
+
+
+@pytest.fixture
+async def credentials_block():
+    credentials_block = GcpCredentials()
+    await credentials_block.save("test-for-publish", overwrite=True)
+    return credentials_block
+
+
+@pytest.fixture
+def base_job_template_with_defaults(default_base_job_template, credentials_block):
+    base_job_template_with_defaults = deepcopy(default_base_job_template)
+    base_job_template_with_defaults["variables"]["properties"]["command"][
+        "default"
+    ] = "python my_script.py"
+    base_job_template_with_defaults["variables"]["properties"]["env"]["default"] = {
+        "VAR1": "value1",
+        "VAR2": "value2",
+    }
+    base_job_template_with_defaults["variables"]["properties"]["labels"]["default"] = {
+        "label1": "value1",
+        "label2": "value2",
+    }
+    base_job_template_with_defaults["variables"]["properties"]["name"][
+        "default"
+    ] = "prefect-job"
+    base_job_template_with_defaults["variables"]["properties"]["image"][
+        "default"
+    ] = "docker.io/my_image:latest"
+    base_job_template_with_defaults["variables"]["properties"]["cpu"][
+        "default"
+    ] = "1000m"
+    base_job_template_with_defaults["variables"]["properties"]["memory"][
+        "default"
+    ] = "512Mi"
+    base_job_template_with_defaults["variables"]["properties"]["timeout"][
+        "default"
+    ] = 60
+    base_job_template_with_defaults["variables"]["properties"]["vpc_connector_name"][
+        "default"
+    ] = "my-vpc-connector"
+    base_job_template_with_defaults["variables"]["properties"]["keep_job"][
+        "default"
+    ] = True
+    base_job_template_with_defaults["variables"]["properties"]["credentials"][
+        "default"
+    ] = {"$ref": {"block_document_id": str(credentials_block._block_document_id)}}
+    base_job_template_with_defaults["variables"]["properties"]["region"][
+        "default"
+    ] = "us-central1"
+    base_job_template_with_defaults["variables"]["properties"]["args"] = {
+        "title": "Arguments",
+        "type": "string",
+        "description": "Arguments to be passed to your Cloud Run Job's entrypoint command.",  # noqa
+        "default": ["--arg1", "value1", "--arg2", "value2"],
+    }
+    base_job_template_with_defaults["job_configuration"]["job_body"]["spec"][
+        "template"
+    ]["spec"]["template"]["spec"]["containers"][0]["args"] = "{{ args }}"
+
+    return base_job_template_with_defaults
+
+
+@pytest.mark.parametrize(
+    "job_config",
+    [
+        "default",
+        "custom",
+    ],
+)
+async def test_generate_work_pool_base_job_template(
+    job_config,
+    base_job_template_with_defaults,
+    credentials_block,
+    default_base_job_template,
+):
+    job = CloudRunJob(
+        image="docker.io/my_image:latest",
+        region="us-central1",
+        credentials=credentials_block,
+    )
+    expected_template = default_base_job_template
+    expected_template["variables"]["properties"]["image"][
+        "default"
+    ] = "docker.io/my_image:latest"
+    expected_template["variables"]["properties"]["region"]["default"] = "us-central1"
+    expected_template["variables"]["properties"]["credentials"]["default"] = {
+        "$ref": {"block_document_id": str(credentials_block._block_document_id)}
+    }
+    if job_config == "custom":
+        expected_template = base_job_template_with_defaults
+        job = CloudRunJob(
+            command=["python", "my_script.py"],
+            env={"VAR1": "value1", "VAR2": "value2"},
+            labels={"label1": "value1", "label2": "value2"},
+            name="prefect-job",
+            image="docker.io/my_image:latest",
+            cpu=1,
+            memory=512,
+            memory_unit="Mi",
+            timeout=60,
+            vpc_connector_name="my-vpc-connector",
+            keep_job=True,
+            credentials=credentials_block,
+            region="us-central1",
+            args=["--arg1", "value1", "--arg2", "value2"],
+        )
+
+    template = await job.generate_work_pool_base_job_template()
+
+    assert template == expected_template


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Implements `generate_work_pool_base_job_template` on the `CloudRun` block to allow users to use a `CloudRun` infrastructure block to create a `cloud-run` work pool.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
