### PR TITLE
Adds ability to publish `VertexAICustomTrainingJob` block as a vertex-ai work pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Modified default command logic in `CloudRunWorkerJobV2Configuration` to utilize the `BaseJobConfiguration._base_flow_run_command` method.
-
 ### Security
+
+## 0.5.5
+
+Released December 11th, 2023.
+
+### Added
+
+- Ability to publish `CloudRun` blocks as cloud-run work pools - [#237](https://github.com/PrefectHQ/prefect-gcp/pull/237)
+- Ability to publish `VertexAICustomTrainingJob` blocks as a vertex-ai work pool - [#238](https://github.com/PrefectHQ/prefect-gcp/pull/238)
+
+### Fixed
+
+- Modified default command logic in `CloudRunWorkerJobV2Configuration` to utilize the `BaseJobConfiguration._base_flow_run_command` method.
 
 ## 0.5.4
 

--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -54,6 +54,7 @@ Examples:
 
 import datetime
 import re
+import shlex
 import time
 from typing import Dict, List, Optional, Tuple
 from uuid import uuid4
@@ -91,6 +92,11 @@ try:
     from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 except ModuleNotFoundError:
     pass
+
+from prefect.blocks.core import BlockNotSavedError
+from prefect.workers.utilities import (
+    get_default_base_job_template_for_infrastructure_type,
+)
 
 from prefect_gcp.credentials import GcpCredentials
 
@@ -247,6 +253,70 @@ class VertexAICustomTrainingJob(Infrastructure):
             labels=self._get_compatible_labels(),
         )
         return str(custom_job)  # outputs a json string
+
+    def get_corresponding_worker_type(self) -> str:
+        """Return the corresponding worker type for this infrastructure block."""
+        return "vertex-ai"
+
+    async def generate_work_pool_base_job_template(self) -> dict:
+        """
+        Generate a base job template for a cloud-run work pool with the same
+        configuration as this block.
+        Returns:
+            - dict: a base job template for a cloud-run work pool
+        """
+        base_job_template = await get_default_base_job_template_for_infrastructure_type(
+            self.get_corresponding_worker_type(),
+        )
+        assert (
+            base_job_template is not None
+        ), "Failed to generate default base job template for Cloud Run worker."
+        for key, value in self.dict(exclude_unset=True, exclude_defaults=True).items():
+            if key == "command":
+                base_job_template["variables"]["properties"]["command"][
+                    "default"
+                ] = shlex.join(value)
+            elif key in [
+                "type",
+                "block_type_slug",
+                "_block_document_id",
+                "_block_document_name",
+                "_is_anonymous",
+            ]:
+                continue
+            elif key == "gcp_credentials":
+                if not self.gcp_credentials._block_document_id:
+                    raise BlockNotSavedError(
+                        "It looks like you are trying to use a block that"
+                        " has not been saved. Please call `.save` on your block"
+                        " before publishing it as a work pool."
+                    )
+                base_job_template["variables"]["properties"]["credentials"][
+                    "default"
+                ] = {
+                    "$ref": {
+                        "block_document_id": str(
+                            self.gcp_credentials._block_document_id
+                        )
+                    }
+                }
+            elif key == "maximum_run_time":
+                base_job_template["variables"]["properties"]["maximum_run_time_hours"][
+                    "default"
+                ] = round(value.total_seconds() / 3600)
+            elif key == "service_account":
+                base_job_template["variables"]["properties"]["service_account_name"][
+                    "default"
+                ] = value
+            elif key in base_job_template["variables"]["properties"]:
+                base_job_template["variables"]["properties"][key]["default"] = value
+            else:
+                self.logger.warning(
+                    f"Variable {key!r} is not supported by Cloud Run work pools."
+                    " Skipping."
+                )
+
+        return base_job_template
 
     def _build_job_spec(self) -> "CustomJobSpec":
         """

--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -260,10 +260,10 @@ class VertexAICustomTrainingJob(Infrastructure):
 
     async def generate_work_pool_base_job_template(self) -> dict:
         """
-        Generate a base job template for a cloud-run work pool with the same
+        Generate a base job template for a `Vertex AI` work pool with the same
         configuration as this block.
         Returns:
-            - dict: a base job template for a cloud-run work pool
+            - dict: a base job template for a `Vertex AI` work pool
         """
         base_job_template = await get_default_base_job_template_for_infrastructure_type(
             self.get_corresponding_worker_type(),
@@ -312,7 +312,7 @@ class VertexAICustomTrainingJob(Infrastructure):
                 base_job_template["variables"]["properties"][key]["default"] = value
             else:
                 self.logger.warning(
-                    f"Variable {key!r} is not supported by Cloud Run work pools."
+                    f"Variable {key!r} is not supported by `Vertex AI` work pools."
                     " Skipping."
                 )
 

--- a/tests/test_aiplatform.py
+++ b/tests/test_aiplatform.py
@@ -271,6 +271,7 @@ async def test_generate_work_pool_base_job_template(
     job = VertexAICustomTrainingJob(
         image="docker.io/my_image:latest",
         region="us-central1",
+        gcp_credentials=credentials_block,
     )
     expected_template = default_base_job_template
     default_base_job_template["variables"]["properties"]["image"][
@@ -279,6 +280,9 @@ async def test_generate_work_pool_base_job_template(
     default_base_job_template["variables"]["properties"]["region"][
         "default"
     ] = "us-central1"
+    default_base_job_template["variables"]["properties"]["credentials"]["default"] = {
+        "$ref": {"block_document_id": str(credentials_block._block_document_id)}
+    }
     if job_config == "custom":
         expected_template = base_job_template_with_defaults
         job = VertexAICustomTrainingJob(


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Implements `generate_work_pool_base_job_template` on the`VertexAICustomTrainingJob` block to allow users to use a VertexAICustomTrainingJob`infrastructure block to create a vertex-ai work pool.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
