### PR TITLE
added labels api field to cloud run v2 job template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `service_account_name` to Cloud Run v2 default template and variables - [#231](https://github.com/PrefectHQ/prefect-gcp/pull/231)
+- Added `labels` to Cloud Run v2 default template - [#240](https://github.com/PrefectHQ/prefect-gcp/pull/231)
 
 ### Changed
 

--- a/prefect_gcp/workers/cloud_run_v2.py
+++ b/prefect_gcp/workers/cloud_run_v2.py
@@ -46,6 +46,7 @@ def _get_default_job_body_template() -> Dict[str, Any]:
     """
     return {
         "client": "prefect",
+        "labels": "{{ labels }}",
         "launchStage": "{{ launch_stage }}",
         "template": {
             "template": {


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Adds the `labels` field for the Cloud Run v2 API to the Cloud Run v2 worker base job template so the `Labels` variable in the Cloud Run v2 work pool has the intended effect.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

![image](https://github.com/PrefectHQ/prefect-gcp/assets/146098880/710e6ad9-afa2-4cf6-8ba4-e474bee00b83)

![image](https://github.com/PrefectHQ/prefect-gcp/assets/146098880/972fa120-c4ef-418c-80de-4acaacce19ad)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-gcp/blob/main/CHANGELOG.md)
