### PR TITLE
Fixed VPC Connector usage in Cloud Run Worker v2

### DIFF
--- a/prefect_gcp/workers/cloud_run_v2.py
+++ b/prefect_gcp/workers/cloud_run_v2.py
@@ -54,6 +54,7 @@ def _get_default_job_body_template() -> Dict[str, Any]:
                 "serviceAccount": "{{ service_account_name }}",
                 "maxRetries": "{{ max_retries }}",
                 "timeout": "{{ timeout }}",
+                "vpcAccess": "{{ vpc_connector_name }}",
                 "containers": [
                     {
                         "env": [],
@@ -183,6 +184,7 @@ class CloudRunWorkerJobV2Configuration(BaseJobConfiguration):
         self._format_args_if_present()
         self._populate_image_if_not_present()
         self._populate_timeout()
+        self._populate_vpc_if_present()
 
     def _populate_timeout(self):
         """
@@ -232,6 +234,15 @@ class CloudRunWorkerJobV2Configuration(BaseJobConfiguration):
             self.job_body["template"]["template"]["containers"][0][
                 "args"
             ] = shlex.split(args)
+
+    def _populate_vpc_if_present(self):
+        """
+        Populates the job body with the VPC connector if present.
+        """
+        if self.job_body["template"]["template"].get("vpcAccess") is not None:
+            self.job_body["template"]["template"]["vpcAccess"] = {
+                "connector": self.job_body["template"]["template"]["vpcAccess"],
+            }
 
     # noinspection PyMethodParameters
     @validator("job_body")

--- a/tests/test_cloud_run_worker_v2.py
+++ b/tests/test_cloud_run_worker_v2.py
@@ -15,7 +15,7 @@ def job_body():
             "template": {
                 "maxRetries": None,
                 "timeout": None,
-                "vpcAccess": "projects/my_project/locations/us-central1/connectors/my-connector",
+                "vpcAccess": "projects/my_project/locations/us-central1/connectors/my-connector",  # noqa: E501
                 "containers": [
                     {
                         "env": [],
@@ -125,6 +125,9 @@ class TestCloudRunWorkerJobV2Configuration:
     def test_populate_vpc_if_present(self, cloud_run_worker_v2_job_config):
         cloud_run_worker_v2_job_config._populate_vpc_if_present()
 
-        assert cloud_run_worker_v2_job_config.job_body["template"]["template"][
-            "vpcAccess"
-        ]["connector"] == "projects/my_project/locations/us-central1/connectors/my-connector"
+        assert (
+            cloud_run_worker_v2_job_config.job_body["template"]["template"][
+                "vpcAccess"
+            ]["connector"]
+            == "projects/my_project/locations/us-central1/connectors/my-connector"
+        )

--- a/tests/test_cloud_run_worker_v2.py
+++ b/tests/test_cloud_run_worker_v2.py
@@ -15,6 +15,7 @@ def job_body():
             "template": {
                 "maxRetries": None,
                 "timeout": None,
+                "vpcAccess": "projects/my_project/locations/us-central1/connectors/my-connector",
                 "containers": [
                     {
                         "env": [],
@@ -120,3 +121,10 @@ class TestCloudRunWorkerJobV2Configuration:
         assert cloud_run_worker_v2_job_config.job_body["template"]["template"][
             "containers"
         ][0]["args"] == ["-m", "prefect.engine"]
+
+    def test_populate_vpc_if_present(self, cloud_run_worker_v2_job_config):
+        cloud_run_worker_v2_job_config._populate_vpc_if_present()
+
+        assert cloud_run_worker_v2_job_config.job_body["template"]["template"][
+            "vpcAccess"
+        ]["connector"] == "projects/my_project/locations/us-central1/connectors/my-connector"


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes
#251 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
- VPC Connector Name in action in Cloud Run
![Screenshot 2024-03-01 at 10 28 00 AM](https://github.com/PrefectHQ/prefect-gcp/assets/21957238/cd128794-df73-49d9-aff9-cc2a1d092470)

- VPC Connector Name being declared in Prefect Advanced Config Job Options (can also be declared in the normal configuration selection menu)
![Screenshot 2024-03-01 at 10 28 19 AM](https://github.com/PrefectHQ/prefect-gcp/assets/21957238/a3677adf-31c2-4add-a8fa-024b94a03d97)

- VPC Connector Name left blank shows `None` in Cloud Run and runs successfully
![Screenshot 2024-03-01 at 12 17 00 PM](https://github.com/PrefectHQ/prefect-gcp/assets/21957238/bdcaecc2-abfa-4f56-a042-619d1fb297c9)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
  - n/a
