### PR TITLE
Deprecate `CloudRunJob` and `VertexAICustomTrainingJob` infrastructure blocks

### DIFF
--- a/prefect_gcp/aiplatform.py
+++ b/prefect_gcp/aiplatform.py
@@ -1,5 +1,10 @@
 """
-<span class="badge-api experimental"/>
+DEPRECATION WARNING:
+
+This module is deprecated as of March 2024 and will not be available after September 2024.
+It has been replaced by the Vertex AI worker, which offers enhanced functionality and better performance.
+
+For upgrade instructions, see https://docs.prefect.io/latest/guides/upgrade-guide-agents-to-workers/.
 
 Integrations with Google AI Platform.
 
@@ -50,7 +55,7 @@ Examples:
     )
     job.preview()
     ```
-"""
+"""  # noqa
 
 import datetime
 import re
@@ -60,6 +65,7 @@ from typing import Dict, List, Optional, Tuple
 from uuid import uuid4
 
 from anyio.abc import TaskStatus
+from prefect._internal.compatibility.deprecated import deprecated_class
 from prefect.exceptions import InfrastructureNotFound
 from prefect.infrastructure import Infrastructure, InfrastructureResult
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
@@ -107,6 +113,14 @@ class VertexAICustomTrainingJobResult(InfrastructureResult):
     """Result from a Vertex AI custom training job."""
 
 
+@deprecated_class(
+    start_date="Mar 2024",
+    help=(
+        "Use the Vertex AI worker instead."
+        " Refer to the upgrade guide for more information:"
+        " https://docs.prefect.io/latest/guides/upgrade-guide-agents-to-workers/."
+    ),
+)
 class VertexAICustomTrainingJob(Infrastructure):
     """
     Infrastructure block used to run Vertex AI custom training jobs.

--- a/prefect_gcp/cloud_run.py
+++ b/prefect_gcp/cloud_run.py
@@ -1,5 +1,10 @@
 """
-<span class="badge-api experimental"/>
+DEPRECATION WARNING:
+
+This module is deprecated as of March 2024 and will not be available after September 2024.
+It has been replaced by the Cloud Run and Cloud Run V2 workers, which offer enhanced functionality and better performance.
+
+For upgrade instructions, see https://docs.prefect.io/latest/guides/upgrade-guide-agents-to-workers/.
 
 Integrations with Google Cloud Run Job.
 
@@ -26,7 +31,7 @@ Examples:
     ).run()
     ```
 
-"""
+"""  # noqa
 
 from __future__ import annotations
 
@@ -42,6 +47,7 @@ from anyio.abc import TaskStatus
 from google.api_core.client_options import ClientOptions
 from googleapiclient import discovery
 from googleapiclient.discovery import Resource
+from prefect._internal.compatibility.deprecated import deprecated_class
 from prefect.exceptions import InfrastructureNotFound
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
@@ -210,6 +216,14 @@ class CloudRunJobResult(InfrastructureResult):
     """Result from a Cloud Run Job."""
 
 
+@deprecated_class(
+    start_date="Mar 2024",
+    help=(
+        "Use the Cloud Run or Cloud Run v2 worker instead."
+        " Refer to the upgrade guide for more information:"
+        " https://docs.prefect.io/latest/guides/upgrade-guide-agents-to-workers/."
+    ),
+)
 class CloudRunJob(Infrastructure):
     """
     <span class="badge-api experimental"/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prefect>=2.14.10
+prefect>=2.16.4
 google-api-python-client>=2.20.0
 google-cloud-storage>=2.0.0
 tenacity>=8.0.0

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -6,24 +6,31 @@ from prefect_gcp.cloud_run import CloudRunJob
 
 
 @pytest.mark.parametrize(
-    "InfraBlock, expected_message",
+    "InfraBlock, kwargs, expected_message",
     [
         (
             CloudRunJob,
+            {"image": "foo", "region": "us-central1"},
             "prefect_gcp.cloud_run.CloudRunJob has been deprecated."
-            " It will not be available after Sep 2024."
-            " Use the Vertex AI worker instead."
-            " Refer to the upgrade guide for more information",
-        ),
-        (
-            VertexAICustomTrainingJob,
-            "prefect_gcp.aiplaform.VertexAICustomTrainingJob has been deprecated."
             " It will not be available after Sep 2024."
             " Use the Cloud Run or Cloud Run v2 worker instead."
             " Refer to the upgrade guide for more information",
         ),
+        (
+            VertexAICustomTrainingJob,
+            {"image": "foo", "region": "us-central1"},
+            "prefect_gcp.aiplatform.VertexAICustomTrainingJob has been deprecated."
+            " It will not be available after Sep 2024."
+            " Use the Vertex AI worker instead."
+            " Refer to the upgrade guide for more information",
+        ),
     ],
 )
-def test_infra_blocks_emit_a_deprecation_warning(InfraBlock, expected_message):
+def test_infra_blocks_emit_a_deprecation_warning(
+    InfraBlock, kwargs, expected_message, gcp_credentials
+):
     with pytest.warns(PrefectDeprecationWarning, match=expected_message):
-        InfraBlock()
+        if InfraBlock == CloudRunJob:
+            InfraBlock(**kwargs, credentials=gcp_credentials)
+        else:
+            InfraBlock(**kwargs, gcp_credentials=gcp_credentials)

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,29 @@
+import pytest
+from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
+
+from prefect_gcp.aiplatform import VertexAICustomTrainingJob
+from prefect_gcp.cloud_run import CloudRunJob
+
+
+@pytest.mark.parametrize(
+    "InfraBlock, expected_message",
+    [
+        (
+            CloudRunJob,
+            "prefect_gcp.cloud_run.CloudRunJob has been deprecated."
+            " It will not be available after Sep 2024."
+            " Use the Vertex AI worker instead."
+            " Refer to the upgrade guide for more information",
+        ),
+        (
+            VertexAICustomTrainingJob,
+            "prefect_gcp.aiplaform.VertexAICustomTrainingJob has been deprecated."
+            " It will not be available after Sep 2024."
+            " Use the Cloud Run or Cloud Run v2 worker instead."
+            " Refer to the upgrade guide for more information",
+        ),
+    ],
+)
+def test_infra_blocks_emit_a_deprecation_warning(InfraBlock, expected_message):
+    with pytest.warns(PrefectDeprecationWarning, match=expected_message):
+        InfraBlock()


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Adds a deprecation warning to the `CloudRunJob` and `VertexAICustomTrainingJob` blocks. The Cloud Run or Vertex AI worker should be used instead.

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
