### PR TITLE
Add GCP firestore components

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           python -m build --sdist --wheel --outdir dist/
 
       - name: Publish build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built-package
           path: "./dist"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## 0.1.0
+
+Released on ???
+
+### Added
+
+- firestore.py --> `firestore_create_collection`, `firestore_create_document`, `firestore_read_collection`, `firestore_update_document`, `firestore_delete_document`, `firestore_read_document`, `firestore_query_collection` ( Add GCP firestore #258 )
+- credentials.py --> `get_firestore_client` ( Add GCP firestore #258 )

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -1,0 +1,1 @@
+::: prefect_gcp.firestore

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
         - Cloud Run V2: cloud_run_v2.md
         - AI Platform: aiplatform.md
         - Deployment Steps: deployments/steps.md
+        - Firestore: firestore.md
         - Workers:
           - Cloud Run: cloud_run_worker.md
           - Cloud Run V2: cloud_run_worker_v2.md

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -39,6 +39,12 @@ try:
 except ModuleNotFoundError:
     pass
 
+try:
+    from google.cloud import firestore
+except ModuleNotFoundError:
+    pass
+
+
 
 def _raise_help_msg(key: str):
     """
@@ -467,3 +473,42 @@ class GcpCredentials(CredentialsBlock):
             credentials=credentials, client_options=client_options
         )
         return job_service_client
+    @_raise_help_msg("firestore")
+    def get_firestore_client(
+        self,
+        project: Optional[str] = None,
+        location: str = "us-central1"
+    ) -> "firestore.Client":
+        """
+        Gets an authenticated Firestore client.
+
+        Args:
+            project: Name of the project to use; overrides the base class's project if provided.
+            location: Location of the Firestore instance.
+
+        Returns:
+            An authenticated Firestore client.
+
+        Examples:
+            Gets a GCP Firestore client.
+            ```python
+            from credentials import GcpCredentials
+
+            gcp_credentials = GcpCredentials()
+            firestore_client = gcp_credentials.get_firestore_client()
+            ```
+
+            Gets a GCP Firestore client with a specific project.
+            ```python
+            from credentials import GcpCredentials
+
+            gcp_credentials = GcpCredentials()
+            firestore_client = gcp_credentials.get_firestore_client(project="my-project")
+            ```
+        """
+        credentials = self.get_credentials_from_service_account()
+
+        # override class project if method project is provided
+        project = project or self.project
+        firestore_client = firestore.Client(credentials=credentials, project=project, location=location)
+        return firestore_client

--- a/prefect_gcp/credentials.py
+++ b/prefect_gcp/credentials.py
@@ -14,6 +14,9 @@ from prefect.blocks.fields import SecretDict
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 from pydantic import VERSION as PYDANTIC_VERSION
 
+import firebase_admin
+from firebase_admin import initialize_app, firestore
+
 if PYDANTIC_VERSION.startswith("2."):
     from pydantic.v1 import Field, root_validator, validator
 else:
@@ -477,7 +480,7 @@ class GcpCredentials(CredentialsBlock):
     def get_firestore_client(
         self,
         project: Optional[str] = None,
-        location: str = "us-central1"
+        location: Optional[str] = None,
     ) -> "firestore.Client":
         """
         Gets an authenticated Firestore client.
@@ -510,5 +513,6 @@ class GcpCredentials(CredentialsBlock):
 
         # override class project if method project is provided
         project = project or self.project
-        firestore_client = firestore.Client(credentials=credentials, project=project, location=location)
+        app = firebase_admin.initialize_app(credentials)
+        firestore_client = firestore.Client(app, credentials=credentials, project=project, location=location)
         return firestore_client

--- a/prefect_gcp/deployments/steps.py
+++ b/prefect_gcp/deployments/steps.py
@@ -1,6 +1,7 @@
 """
 Prefect deployment steps for code storage in and retrieval from Google Cloud Storage.
 """
+
 from pathlib import Path, PurePosixPath
 from typing import Dict, Optional
 

--- a/prefect_gcp/firestore.py
+++ b/prefect_gcp/firestore.py
@@ -1,10 +1,17 @@
 import os
 from google.cloud import firestore
+import firebase_admin
+from firebase_admin import initialize_app, firestore, credentials
 from google.cloud.firestore_v1 import DocumentReference
+from google.cloud.firestore_v1.query import BaseQuery
+
+from google.cloud.firestore_v1.collection import CollectionReference
 from prefect import get_run_logger, task
 from typing import Optional, List, Dict, Any
 from typing import Union
 from prefect_gcp.credentials import GcpCredentials
+import pytest
+
 
 
 @task
@@ -357,6 +364,7 @@ async def firestore_query_collection(
         return_whole_document: bool = False,
         project: Optional[str] = None,
         location: Optional[str] = None,
+        limit_value: Optional[int] = 50,
     ) -> Union[List[str], List[Dict[str, Any]]]:
         """
         Queries a Firestore collection for a specific value.
@@ -404,8 +412,8 @@ async def firestore_query_collection(
 
         firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
 
-        query = firestore_client.collection(collection).where(query_key, "==", query_value)
-        query.limit(50)
+        query = firestore_client.collection(collection).where(field_path= query_key, op_string="==", value=query_value)
+        query.limit(limit_value)
 
         documents = await query.get()
 

--- a/prefect_gcp/firestore.py
+++ b/prefect_gcp/firestore.py
@@ -3,6 +3,7 @@ from google.cloud import firestore
 from google.cloud.firestore_v1 import DocumentReference
 from prefect import get_run_logger, task
 from typing import Optional, List, Dict, Any
+from typing import Union
 from prefect_gcp.credentials import GcpCredentials
 
 
@@ -290,5 +291,134 @@ async def firestore_delete_document(
     await doc_ref.delete()
 
     logger.info("Document %s deleted from collection: %s", document_id, collection)
+
+    #add read document task
+@task
+async def firestore_read_document(
+        collection: str,
+        document_id: str,
+        gcp_credentials: GcpCredentials,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Reads a document from a Firestore collection.
+        Args:
+            collection: Name of the collection containing the document.
+            document_id: ID of the document to read.
+            gcp_credentials: Credentials to use for authentication with GCP.
+            project: Project ID where Firestore exists.
+            location: The location of the Firestore instance.
+        Returns:
+            Dictionary representing the document.
+        Example:
+            Reads a document with ID "123" from the "users" collection using a Prefect flow.
+            ```python
+            from prefect import Flow
+            from prefect_gcp import GcpCredentials
+            from prefect_gcp.firestore import firestore_read_document
+
+            @Flow()
+            def example_firestore_read_document_flow():
+                gcp_credentials = GcpCredentials(
+                    service_account_file="/path/to/service/account/keyfile.json"
+                )
+                document_data = firestore_read_document(
+                    collection="users",
+                    document_id="123",
+                    gcp_credentials=gcp_credentials,
+                    project="my-project"
+                )
+                print(document_data)
+
+            example_firestore_read_document_flow()
+            ```
+        """
+        if not project:
+            raise ValueError("Project ID must be provided.")
+
+        firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+
+        collection_ref = firestore_client.collection(collection)
+        doc_ref = collection_ref.document(document_id)
+
+        document = await doc_ref.get()
+        document_data = document.to_dict()
+
+        return document_data
+
+    #add query collection task - default false = paramter / option if false return the id from query or if true the whole ducument & a limit on how many can be returned 
+@task
+async def firestore_query_collection(
+        collection: str,
+        gcp_credentials: GcpCredentials,
+        query_key: str,
+        query_value: Any,
+        return_whole_document: bool = False,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+    ) -> Union[List[str], List[Dict[str, Any]]]:
+        """
+        Queries a Firestore collection for a specific value.
+        Args:
+            collection: Name of the collection to query.
+            gcp_credentials: Credentials to use for authentication with GCP.
+            query_key: Key to query on.
+            query_value: Value to query for.
+            return_whole_document: If True, returns the entire document. If False, returns only the document ID.
+            project: Project ID where Firestore exists.
+            location: The location of the Firestore instance.
+        Returns:
+            List of document IDs or list of dictionaries representing the documents, depending on the value of return_whole_document.
+        Example:
+            Queries the "users" collection in Firestore for documents where "age" equals 30, returning only the document IDs.
+            ```python
+            from prefect import Flow
+            from prefect_gcp import GcpCredentials
+            from prefect_gcp.firestore import firestore_query_collection
+
+            @Flow()
+            def example_firestore_query_collection_flow():
+                gcp_credentials = GcpCredentials(
+                    service_account_file="/path/to/service/account/keyfile.json"
+                )
+                document_ids = firestore_query_collection(
+                    collection="users",
+                    query_key="age",
+                    query_value=30,
+                    return_whole_document=False,
+                    gcp_credentials=gcp_credentials,
+                    project="my-project"
+                )
+                for document_id in document_ids:
+                    print(document_id)
+
+            example_firestore_query_collection_flow()
+            ```
+        """
+        logger = get_run_logger()
+        logger.info("Querying collection: %s", collection)
+
+        if not project:
+            raise ValueError("Project ID must be provided.")
+
+        firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+
+        query = firestore_client.collection(collection).where(query_key, "==", query_value)
+        query.limit(50)
+
+        documents = await query.get()
+
+        if return_whole_document:
+            documents_data = [doc.to_dict() for doc in documents]
+        else:
+            documents_data = [doc.id for doc in documents]
+
+        logger.info("Query returned %s documents", len(documents_data))
+        return documents_data
+
+
+
+
 
 

--- a/prefect_gcp/firestore.py
+++ b/prefect_gcp/firestore.py
@@ -11,7 +11,7 @@ async def firestore_create_collection(
     collection: str,
     gcp_credentials: GcpCredentials,
     project: Optional[str] = None,
-    location: str = "us-central1",
+    location: Optional[str] = None,
 ) -> DocumentReference:
     """
     Creates a collection in Firestore.
@@ -63,7 +63,7 @@ async def firestore_create_document(
     document_data: Dict[str, Any],
     gcp_credentials: GcpCredentials,
     project: Optional[str] = None,
-    location: str = "us-central1",
+    location: Optional[str] = None,
 ) -> DocumentReference:
     """
     Creates a document in a Firestore collection.
@@ -118,7 +118,7 @@ async def firestore_read_collection(
     collection: str,
     gcp_credentials: GcpCredentials,
     project: Optional[str] = None,
-    location: str = "us-central1",
+    location: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Reads all documents from a Firestore collection.
@@ -178,7 +178,7 @@ async def firestore_update_document(
     update_data: Dict[str, Any],
     gcp_credentials: GcpCredentials,
     project: Optional[str] = None,
-    location: str = "us-central1",
+    location: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Updates a document in a Firestore collection.
@@ -242,7 +242,7 @@ async def firestore_delete_document(
     document_id: str,
     gcp_credentials: GcpCredentials,
     project: Optional[str] = None,
-    location: str = "us-central1",
+    location: Optional[str] = None,
 ) -> None:
     """
     Deletes a document from a Firestore collection.

--- a/prefect_gcp/firestore.py
+++ b/prefect_gcp/firestore.py
@@ -1,17 +1,26 @@
-import os
-from google.cloud import firestore
-import firebase_admin
-from firebase_admin import initialize_app, firestore, credentials
+"""Tasks for interacting with GCP Firestore"""
+
+from typing import Any, Dict, List, Optional, Union
+
 from google.cloud.firestore_v1 import DocumentReference
-from google.cloud.firestore_v1.query import BaseQuery
-
-from google.cloud.firestore_v1.collection import CollectionReference
 from prefect import get_run_logger, task
-from typing import Optional, List, Dict, Any
-from typing import Union
-from prefect_gcp.credentials import GcpCredentials
-import pytest
 
+from prefect_gcp.credentials import GcpCredentials
+
+"""
+Firestore Module
+~~~~~~~~~~~~~~~
+This module provides tasks for interacting with Firestore in Google Cloud..
+Platform (GCP).
+Tasks:
+    - `firestore_create_collection`: Creates a collection in Firestore.
+    - `firestore_create_document`: Creates a document in a Firestore collection.
+    - `firestore_read_collection`: Reads all documents from a Firestore collection.
+    - `firestore_update_document`: Updates a document in a Firestore collection.
+    - `firestore_delete_document`: Deletes a document from a Firestore collection.
+    - `firestore_read_document`: Reads a document from a Firestore collection.
+    - `firestore_query_collection`: Queries a Firestore collection for a specific value.
+"""
 
 
 @task
@@ -49,7 +58,7 @@ async def firestore_create_collection(
             )
 
         example_firestore_create_collection_flow()
-        ```   
+        ```
     """
     logger = get_run_logger()
     logger.info("Creating collection: %s", collection)
@@ -57,7 +66,9 @@ async def firestore_create_collection(
     if not project:
         raise ValueError("Project ID must be provided.")
 
-    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+    firestore_client = gcp_credentials.get_firestore_client(
+        project=project, location=location
+    )
 
     collection_ref = firestore_client.collection(collection)
 
@@ -84,7 +95,8 @@ async def firestore_create_document(
     Returns:
         Reference to the created document.
     Example:
-        Creates a document with data {"name": "John", "age": 30} in the "users" collection using a Prefect flow.
+        Creates a document with data {"name": "John", "age": 30} in
+        the "users" collection using a Prefect flow.
         ```python
         from prefect import Flow
         from prefect_gcp import GcpCredentials
@@ -112,7 +124,9 @@ async def firestore_create_document(
     if not project:
         raise ValueError("Project ID must be provided.")
 
-    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+    firestore_client = gcp_credentials.get_firestore_client(
+        project=project, location=location
+    )
 
     collection_ref = firestore_client.collection(collection)
     doc_ref = await collection_ref.add(document_data)
@@ -138,7 +152,8 @@ async def firestore_read_collection(
     Returns:
         List of dictionaries representing the documents.
     Example:
-        Reads all documents from the "users" collection in Firestore using a Prefect flow.
+        Reads all documents from the "users" collection in Firestore..
+        ..using a Prefect flow.
         ```python
         from prefect import Flow
         from prefect_gcp import GcpCredentials
@@ -166,7 +181,9 @@ async def firestore_read_collection(
     if not project:
         raise ValueError("Project ID must be provided.")
 
-    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+    firestore_client = gcp_credentials.get_firestore_client(
+        project=project, location=location
+    )
 
     collection_ref = firestore_client.collection(collection)
     documents = await collection_ref.get()
@@ -175,7 +192,9 @@ async def firestore_read_collection(
     for doc in documents:
         documents_data.append(doc.to_dict())
 
-    logger.info("Read %s documents from collection: %s", len(documents_data), collection)
+    logger.info(
+        "Read %s documents from collection: %s", len(documents_data), collection
+    )
     return documents_data
 
 
@@ -200,7 +219,8 @@ async def firestore_update_document(
     Returns:
         Dictionary representing the updated document.
     Example:
-        Updates a document with ID "123" in the "users" collection with new data {"age": 35} using a Prefect flow.
+        Updates a document with ID "123" in the "users" collection with...
+        ...new data {"age": 35} using a Prefect flow.
         ```python
         from prefect import Flow
         from prefect_gcp import GcpCredentials
@@ -230,7 +250,9 @@ async def firestore_update_document(
     if not project:
         raise ValueError("Project ID must be provided.")
 
-    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+    firestore_client = gcp_credentials.get_firestore_client(
+        project=project, location=location
+    )
 
     collection_ref = firestore_client.collection(collection)
     doc_ref = collection_ref.document(document_id)
@@ -263,7 +285,8 @@ async def firestore_delete_document(
     Returns:
         None
     Example:
-        Deletes a document with ID "123" from the "users" collection using a Prefect flow.
+        Deletes a document with ID "123" from the "users" collection...
+        ...using a Prefect flow.
         ```python
         from prefect import Flow
         from prefect_gcp import GcpCredentials
@@ -290,7 +313,9 @@ async def firestore_delete_document(
     if not project:
         raise ValueError("Project ID must be provided.")
 
-    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+    firestore_client = gcp_credentials.get_firestore_client(
+        project=project, location=location
+    )
 
     collection_ref = firestore_client.collection(collection)
     doc_ref = collection_ref.document(document_id)
@@ -299,134 +324,142 @@ async def firestore_delete_document(
 
     logger.info("Document %s deleted from collection: %s", document_id, collection)
 
-    #add read document task
+    # add read document task
+
+
 @task
 async def firestore_read_document(
-        collection: str,
-        document_id: str,
-        gcp_credentials: GcpCredentials,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Reads a document from a Firestore collection.
-        Args:
-            collection: Name of the collection containing the document.
-            document_id: ID of the document to read.
-            gcp_credentials: Credentials to use for authentication with GCP.
-            project: Project ID where Firestore exists.
-            location: The location of the Firestore instance.
-        Returns:
-            Dictionary representing the document.
-        Example:
-            Reads a document with ID "123" from the "users" collection using a Prefect flow.
-            ```python
-            from prefect import Flow
-            from prefect_gcp import GcpCredentials
-            from prefect_gcp.firestore import firestore_read_document
+    collection: str,
+    document_id: str,
+    gcp_credentials: GcpCredentials,
+    project: Optional[str] = None,
+    location: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Reads a document from a Firestore collection.
+    Args:
+        collection: Name of the collection containing the document.
+        document_id: ID of the document to read.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        project: Project ID where Firestore exists.
+        location: The location of the Firestore instance.
+    Returns:
+        Dictionary representing the document.
+    Example:
+        Reads a document with ID "123" from the "users" collection using a Prefect flow.
+        ```python
+        from prefect import Flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.firestore import firestore_read_document
 
-            @Flow()
-            def example_firestore_read_document_flow():
-                gcp_credentials = GcpCredentials(
-                    service_account_file="/path/to/service/account/keyfile.json"
-                )
-                document_data = firestore_read_document(
-                    collection="users",
-                    document_id="123",
-                    gcp_credentials=gcp_credentials,
-                    project="my-project"
-                )
-                print(document_data)
+        @Flow()
+        def example_firestore_read_document_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json"
+            )
+            document_data = firestore_read_document(
+                collection="users",
+                document_id="123",
+                gcp_credentials=gcp_credentials,
+                project="my-project"
+            )
+            print(document_data)
 
-            example_firestore_read_document_flow()
-            ```
-        """
-        if not project:
-            raise ValueError("Project ID must be provided.")
+        example_firestore_read_document_flow()
+        ```
+    """
+    if not project:
+        raise ValueError("Project ID must be provided.")
 
-        firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+    firestore_client = gcp_credentials.get_firestore_client(
+        project=project, location=location
+    )
 
-        collection_ref = firestore_client.collection(collection)
-        doc_ref = collection_ref.document(document_id)
+    collection_ref = firestore_client.collection(collection)
+    doc_ref = collection_ref.document(document_id)
 
-        document = await doc_ref.get()
-        document_data = document.to_dict()
+    document = await doc_ref.get()
+    document_data = document.to_dict()
 
-        return document_data
+    return document_data
 
-    #add query collection task - default false = paramter / option if false return the id from query or if true the whole ducument & a limit on how many can be returned 
+
+# add query collection task - default false = paramter / optionl
+# if false return the id from query or if true the whole ducument &
+# a limit on how many can be returned
+
+
 @task
 async def firestore_query_collection(
-        collection: str,
-        gcp_credentials: GcpCredentials,
-        query_key: str,
-        query_value: Any,
-        return_whole_document: bool = False,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-        limit_value: Optional[int] = 50,
-    ) -> Union[List[str], List[Dict[str, Any]]]:
-        """
-        Queries a Firestore collection for a specific value.
-        Args:
-            collection: Name of the collection to query.
-            gcp_credentials: Credentials to use for authentication with GCP.
-            query_key: Key to query on.
-            query_value: Value to query for.
-            return_whole_document: If True, returns the entire document. If False, returns only the document ID.
-            project: Project ID where Firestore exists.
-            location: The location of the Firestore instance.
-        Returns:
-            List of document IDs or list of dictionaries representing the documents, depending on the value of return_whole_document.
-        Example:
-            Queries the "users" collection in Firestore for documents where "age" equals 30, returning only the document IDs.
-            ```python
-            from prefect import Flow
-            from prefect_gcp import GcpCredentials
-            from prefect_gcp.firestore import firestore_query_collection
+    collection: str,
+    gcp_credentials: GcpCredentials,
+    query_key: str,
+    query_value: Any,
+    return_whole_document: bool = False,
+    project: Optional[str] = None,
+    location: Optional[str] = None,
+    limit_value: Optional[int] = 50,
+) -> Union[List[str], List[Dict[str, Any]]]:
+    """
+    Queries a Firestore collection for a specific value.
+    Args:
+        collection: Name of the collection to query.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        query_key: Key to query on.
+        query_value: Value to query for.
+        return_whole_document: If True, returns the entire document...
+        ...If False, returns only the document ID.
+        project: Project ID where Firestore exists.
+        location: The location of the Firestore instance.
+    Returns:
+        List of document IDs or list of dictionaries representing the documents,
+        depending on the value of return_whole_document.
+    Example:
+        Queries the "users" collection in Firestore for documents where "age" equals 30,
+        returning only the document IDs.
+        ```python
+        from prefect import Flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.firestore import firestore_query_collection
+        @Flow()
+        def example_firestore_query_collection_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json"
+            )
+            document_ids = firestore_query_collection(
+                collection="users",
+                query_key="age",
+                query_value=30,
+                return_whole_document=False,
+                gcp_credentials=gcp_credentials,
+                project="my-project"
+            )
+            for document_id in document_ids:
+                print(document_id)
+        example_firestore_query_collection_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Querying collection: %s", collection)
 
-            @Flow()
-            def example_firestore_query_collection_flow():
-                gcp_credentials = GcpCredentials(
-                    service_account_file="/path/to/service/account/keyfile.json"
-                )
-                document_ids = firestore_query_collection(
-                    collection="users",
-                    query_key="age",
-                    query_value=30,
-                    return_whole_document=False,
-                    gcp_credentials=gcp_credentials,
-                    project="my-project"
-                )
-                for document_id in document_ids:
-                    print(document_id)
+    if not project:
+        raise ValueError("Project ID must be provided.")
 
-            example_firestore_query_collection_flow()
-            ```
-        """
-        logger = get_run_logger()
-        logger.info("Querying collection: %s", collection)
+    firestore_client = gcp_credentials.get_firestore_client(
+        project=project, location=location
+    )
 
-        if not project:
-            raise ValueError("Project ID must be provided.")
+    query = firestore_client.collection(collection).where(
+        field_path=query_key, op_string="==", value=query_value
+    )
+    query.limit(limit_value)
 
-        firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+    documents = await query.get()
 
-        query = firestore_client.collection(collection).where(field_path= query_key, op_string="==", value=query_value)
-        query.limit(limit_value)
+    if return_whole_document:
+        documents_data = [doc.to_dict() for doc in documents]
+    else:
+        documents_data = [doc.id for doc in documents]
 
-        documents = await query.get()
-
-        if return_whole_document:
-            documents_data = [doc.to_dict() for doc in documents]
-        else:
-            documents_data = [doc.id for doc in documents]
-
-        logger.info("Query returned %s documents", len(documents_data))
-        return documents_data
-
-
-
-
-
-
+    logger.info("Query returned %s documents", len(documents_data))
+    return documents_data

--- a/prefect_gcp/firestore.py
+++ b/prefect_gcp/firestore.py
@@ -1,4 +1,294 @@
-from prefect_gcp import GcpCredentials
-GcpCredentials.load("PT-secret-block")
+import os
+from google.cloud import firestore
+from google.cloud.firestore_v1 import DocumentReference
+from prefect import get_run_logger, task
+from typing import Optional, List, Dict, Any
+from prefect_gcp.credentials import GcpCredentials
 
-# Path: prefect_gcp/firestore.py
+
+@task
+async def firestore_create_collection(
+    collection: str,
+    gcp_credentials: GcpCredentials,
+    project: Optional[str] = None,
+    location: str = "us-central1",
+) -> DocumentReference:
+    """
+    Creates a collection in Firestore.
+    Args:
+        collection: Name of the collection to create.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        project: Project ID where Firestore exists.
+        location: The location of the Firestore instance.
+    Returns:
+        Reference to the created collection.
+    Example:
+        Creates a collection named "users" in Firestore using a Prefect flow.
+        ```python
+        from prefect import Flow
+        from prefect_gcp import GcpCredentials
+        from prefecr_gcp.firestore import firestore_create_collection
+
+        @Flow()
+        def example_firestore_create_collection_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json"
+            )
+            collection_ref = firestore_create_collection(
+                collection="users",
+                gcp_credentials=gcp_credentials,
+                project="my-project"
+            )
+
+        example_firestore_create_collection_flow()
+        ```   
+    """
+    logger = get_run_logger()
+    logger.info("Creating collection: %s", collection)
+
+    if not project:
+        raise ValueError("Project ID must be provided.")
+
+    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+
+    collection_ref = firestore_client.collection(collection)
+
+    # Attempt to create the collection (collections in Firestore are created implicitly)
+    return collection_ref
+
+
+@task
+async def firestore_create_document(
+    collection: str,
+    document_data: Dict[str, Any],
+    gcp_credentials: GcpCredentials,
+    project: Optional[str] = None,
+    location: str = "us-central1",
+) -> DocumentReference:
+    """
+    Creates a document in a Firestore collection.
+    Args:
+        collection: Name of the collection to insert the document into.
+        document_data: Data to be inserted into the document.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        project: Project ID where Firestore exists.
+        location: The location of the Firestore instance.
+    Returns:
+        Reference to the created document.
+    Example:
+        Creates a document with data {"name": "John", "age": 30} in the "users" collection using a Prefect flow.
+        ```python
+        from prefect import Flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.firestore import firestore_create_document
+
+        @Flow()
+        def example_firestore_create_document_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json"
+            )
+            document_data = {"name": "John", "age": 30}
+            doc_ref = firestore_create_document(
+                collection="users",
+                document_data=document_data,
+                gcp_credentials=gcp_credentials,
+                project="my-project"
+            )
+
+        example_firestore_create_document_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Creating document in collection: %s", collection)
+
+    if not project:
+        raise ValueError("Project ID must be provided.")
+
+    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+
+    collection_ref = firestore_client.collection(collection)
+    doc_ref = await collection_ref.add(document_data)
+
+    logger.info("Document created: %s", doc_ref.id)
+    return doc_ref
+
+
+@task
+async def firestore_read_collection(
+    collection: str,
+    gcp_credentials: GcpCredentials,
+    project: Optional[str] = None,
+    location: str = "us-central1",
+) -> List[Dict[str, Any]]:
+    """
+    Reads all documents from a Firestore collection.
+    Args:
+        collection: Name of the collection to read documents from.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        project: Project ID where Firestore exists.
+        location: The location of the Firestore instance.
+    Returns:
+        List of dictionaries representing the documents.
+    Example:
+        Reads all documents from the "users" collection in Firestore using a Prefect flow.
+        ```python
+        from prefect import Flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.firestore import firestore_read_collection
+
+        @Flow()
+        def example_firestore_read_collection_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json"
+            )
+            documents = firestore_read_collection(
+                collection="users",
+                gcp_credentials=gcp_credentials,
+                project="my-project"
+            )
+            for document in documents:
+                print(document)
+
+        example_firestore_read_collection_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Reading documents from collection: %s", collection)
+
+    if not project:
+        raise ValueError("Project ID must be provided.")
+
+    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+
+    collection_ref = firestore_client.collection(collection)
+    documents = await collection_ref.get()
+
+    documents_data = []
+    for doc in documents:
+        documents_data.append(doc.to_dict())
+
+    logger.info("Read %s documents from collection: %s", len(documents_data), collection)
+    return documents_data
+
+
+@task
+async def firestore_update_document(
+    collection: str,
+    document_id: str,
+    update_data: Dict[str, Any],
+    gcp_credentials: GcpCredentials,
+    project: Optional[str] = None,
+    location: str = "us-central1",
+) -> Dict[str, Any]:
+    """
+    Updates a document in a Firestore collection.
+    Args:
+        collection: Name of the collection containing the document.
+        document_id: ID of the document to be updated.
+        update_data: Data to be updated in the document.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        project: Project ID where Firestore exists.
+        location: The location of the Firestore instance.
+    Returns:
+        Dictionary representing the updated document.
+    Example:
+        Updates a document with ID "123" in the "users" collection with new data {"age": 35} using a Prefect flow.
+        ```python
+        from prefect import Flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.firestore import firestore_update_document
+
+        @Flow()
+        def example_firestore_update_document_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json"
+            )
+            update_data = {"age": 35}
+            updated_doc = firestore_update_document(
+                collection="users",
+                document_id="123",
+                update_data=update_data,
+                gcp_credentials=gcp_credentials,
+                project="my-project"
+            )
+            print(updated_doc)
+
+        example_firestore_update_document_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Updating document %s in collection: %s", document_id, collection)
+
+    if not project:
+        raise ValueError("Project ID must be provided.")
+
+    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+
+    collection_ref = firestore_client.collection(collection)
+    doc_ref = collection_ref.document(document_id)
+
+    await doc_ref.update(update_data)
+
+    updated_doc = await doc_ref.get()
+    updated_doc_data = updated_doc.to_dict()
+
+    logger.info("Document updated: %s", updated_doc_data)
+    return updated_doc_data
+
+
+@task
+async def firestore_delete_document(
+    collection: str,
+    document_id: str,
+    gcp_credentials: GcpCredentials,
+    project: Optional[str] = None,
+    location: str = "us-central1",
+) -> None:
+    """
+    Deletes a document from a Firestore collection.
+    Args:
+        collection: Name of the collection containing the document.
+        document_id: ID of the document to be deleted.
+        gcp_credentials: Credentials to use for authentication with GCP.
+        project: Project ID where Firestore exists.
+        location: The location of the Firestore instance.
+    Returns:
+        None
+    Example:
+        Deletes a document with ID "123" from the "users" collection using a Prefect flow.
+        ```python
+        from prefect import Flow
+        from prefect_gcp import GcpCredentials
+        from prefect_gcp.firestore import firestore_delete_document
+
+        @Flow()
+        def example_firestore_delete_document_flow():
+            gcp_credentials = GcpCredentials(
+                service_account_file="/path/to/service/account/keyfile.json"
+            )
+            firestore_delete_document(
+                collection="users",
+                document_id="123",
+                gcp_credentials=gcp_credentials,
+                project="my-project"
+            )
+
+        example_firestore_delete_document_flow()
+        ```
+    """
+    logger = get_run_logger()
+    logger.info("Deleting document %s from collection: %s", document_id, collection)
+
+    if not project:
+        raise ValueError("Project ID must be provided.")
+
+    firestore_client = gcp_credentials.get_firestore_client(project=project, location=location)
+
+    collection_ref = firestore_client.collection(collection)
+    doc_ref = collection_ref.document(document_id)
+
+    await doc_ref.delete()
+
+    logger.info("Document %s deleted from collection: %s", document_id, collection)
+
+

--- a/prefect_gcp/firestore.py
+++ b/prefect_gcp/firestore.py
@@ -1,0 +1,4 @@
+from prefect_gcp import GcpCredentials
+GcpCredentials.load("PT-secret-block")
+
+# Path: prefect_gcp/firestore.py

--- a/prefect_gcp/workers/vertex.py
+++ b/prefect_gcp/workers/vertex.py
@@ -18,6 +18,7 @@ prefect worker start --pool 'my-vertex-pool'
 Read more about configuring work pools
 [here](https://docs.prefect.io/latest/concepts/work-pools/#work-pool-overview).
 """
+
 import datetime
 import re
 import shlex

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ google-api-python-client>=2.20.0
 google-cloud-storage>=2.0.0
 tenacity>=8.0.0
 python-slugify>=8.0.0
-firebase-admin>=5.0.0
+firebase-admin
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ google-api-python-client>=2.20.0
 google-cloud-storage>=2.0.0
 tenacity>=8.0.0
 python-slugify>=8.0.0
+firebase-admin>=5.0.0
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ google-api-python-client>=2.20.0
 google-cloud-storage>=2.0.0
 tenacity>=8.0.0
 python-slugify>=8.0.0
-firebase-admin
-```
+firebase-admin>=5.0.0

--- a/tests/test_aiplatform.py
+++ b/tests/test_aiplatform.py
@@ -245,7 +245,10 @@ def base_job_template_with_defaults(default_base_job_template, credentials_block
     ] = "my-network"
     base_job_template_with_defaults["variables"]["properties"]["reserved_ip_ranges"][
         "default"
-    ] = ["172.31.0.0/16", "192.168.0.0./16"]
+    ] = [
+        "172.31.0.0/16",
+        "192.168.0.0./16",
+    ]
     base_job_template_with_defaults["variables"]["properties"]["service_account_name"][
         "default"
     ] = "my-service-account"

--- a/tests/test_firestore.py
+++ b/tests/test_firestore.py
@@ -23,12 +23,12 @@ def gcp_credentials_mock():
 
     return mock_credentials
 
-def test_firestore_create_collection(gcp_credentials_mock):
+def test_firestore_create_collection(gcp_credentials):
     @Flow
     def test_flow():
         collection_ref = firestore_create_collection(
             collection="users",
-            gcp_credentials=gcp_credentials_mock,
+            gcp_credentials=gcp_credentials,
             project="my-project",
             location="us-central1",
         )
@@ -36,14 +36,14 @@ def test_firestore_create_collection(gcp_credentials_mock):
 
     test_flow._run()
 
-def test_firestore_create_document(gcp_credentials_mock):
+def test_firestore_create_document(gcp_credentials):
     @Flow
     def test_flow():
         document_data = {"name": "John", "age": 30}
         document_ref = firestore_create_document(
             collection="users",
             document_data=document_data,
-            gcp_credentials=gcp_credentials_mock,
+            gcp_credentials=gcp_credentials,
             project="my-project",
             location="us-central1",
         )
@@ -51,12 +51,12 @@ def test_firestore_create_document(gcp_credentials_mock):
 
     test_flow._run()
 
-def test_firestore_read_collection(gcp_credentials_mock):
+def test_firestore_read_collection(gcp_credentials):
     @Flow
     def test_flow():
         documents = firestore_read_collection(
             collection="users",
-            gcp_credentials=gcp_credentials_mock,
+            gcp_credentials=gcp_credentials,
             project="my-project",
             location="us-central1",
         )
@@ -64,7 +64,7 @@ def test_firestore_read_collection(gcp_credentials_mock):
 
     test_flow._run()
 
-def test_firestore_update_document(gcp_credentials_mock):
+def test_firestore_update_document(gcp_credentials):
     @Flow
     def test_flow():
         update_data = {"age": 35}
@@ -72,7 +72,7 @@ def test_firestore_update_document(gcp_credentials_mock):
             collection="users",
             document_id="document_id",
             update_data=update_data,
-            gcp_credentials=gcp_credentials_mock,
+            gcp_credentials=gcp_credentials,
             project="my-project",
             location="us-central1",
         )
@@ -80,26 +80,26 @@ def test_firestore_update_document(gcp_credentials_mock):
 
     test_flow._run()
 
-def test_firestore_delete_document(gcp_credentials_mock):
+def test_firestore_delete_document(gcp_credentials):
     @Flow
     def test_flow():
         firestore_delete_document(
             collection="users",
             document_id="document_id",
-            gcp_credentials=gcp_credentials_mock,
+            gcp_credentials=gcp_credentials,
             project="my-project",
             location="us-central1",
         )
 
     test_flow._run()
 
-def test_firestore_read_document(gcp_credentials_mock):
+def test_firestore_read_document(gcp_credentials):
     @Flow
     def test_flow():
         document = firestore_read_document(
             collection="users",
             document_id="document_id",
-            gcp_credentials=gcp_credentials_mock,
+            gcp_credentials=gcp_credentials,
             project="my-project",
             location="us-central1",
         )
@@ -107,12 +107,12 @@ def test_firestore_read_document(gcp_credentials_mock):
 
     test_flow._run()
 
-def test_firestore_query_collection(gcp_credentials_mock):
+def test_firestore_query_collection(gcp_credentials):
     @Flow
     def test_flow():
         documents = firestore_query_collection(
             collection="users",
-            gcp_credentials=gcp_credentials_mock,
+            gcp_credentials=gcp_credentials,
             query_key="age",
             query_value=30,
             return_whole_document=False,

--- a/tests/test_firestore.py
+++ b/tests/test_firestore.py
@@ -1,0 +1,92 @@
+import os
+import pytest
+from prefect import Flow
+from unittest.mock import MagicMock
+from prefect_gcp.firestore import (
+    firestore_create_collection,
+    firestore_create_document,
+    firestore_delete_document,
+    firestore_read_collection,
+    firestore_update_document,
+)
+
+@pytest.fixture
+def gcp_credentials_mock():
+    # Create a MagicMock object to mock the behavior of GcpCredentials
+    mock_credentials = MagicMock()
+
+    # Mock the behavior of get_firestore_client method to return a MagicMock
+    mock_firestore_client = MagicMock()
+    mock_credentials.get_firestore_client.return_value = mock_firestore_client
+
+    return mock_credentials
+
+def test_firestore_create_collection(gcp_credentials_mock):
+    @Flow
+    def test_flow():
+        collection_ref = firestore_create_collection(
+            collection="users",
+            gcp_credentials=gcp_credentials_mock,
+            project="my-project",
+            location="us-central1",
+        )
+        return collection_ref
+
+    test_flow._run()
+
+def test_firestore_create_document(gcp_credentials_mock):
+    @Flow
+    def test_flow():
+        document_data = {"name": "John", "age": 30}
+        document_ref = firestore_create_document(
+            collection="users",
+            document_data=document_data,
+            gcp_credentials=gcp_credentials_mock,
+            project="my-project",
+            location="us-central1",
+        )
+        return document_ref
+
+    test_flow._run()
+
+def test_firestore_read_collection(gcp_credentials_mock):
+    @Flow
+    def test_flow():
+        documents = firestore_read_collection(
+            collection="users",
+            gcp_credentials=gcp_credentials_mock,
+            project="my-project",
+            location="us-central1",
+        )
+        return documents
+
+    test_flow._run()
+
+def test_firestore_update_document(gcp_credentials_mock):
+    @Flow
+    def test_flow():
+        update_data = {"age": 35}
+        updated_doc = firestore_update_document(
+            collection="users",
+            document_id="document_id",
+            update_data=update_data,
+            gcp_credentials=gcp_credentials_mock,
+            project="my-project",
+            location="us-central1",
+        )
+        return updated_doc
+
+    test_flow._run()
+
+def test_firestore_delete_document(gcp_credentials_mock):
+    @Flow
+    def test_flow():
+        firestore_delete_document(
+            collection="users",
+            document_id="document_id",
+            gcp_credentials=gcp_credentials_mock,
+            project="my-project",
+            location="us-central1",
+        )
+
+    test_flow._run()

--- a/tests/test_firestore.py
+++ b/tests/test_firestore.py
@@ -8,6 +8,8 @@ from prefect_gcp.firestore import (
     firestore_delete_document,
     firestore_read_collection,
     firestore_update_document,
+    firestore_read_document,
+    firestore_query_collection,
 )
 
 @pytest.fixture
@@ -88,5 +90,35 @@ def test_firestore_delete_document(gcp_credentials_mock):
             project="my-project",
             location="us-central1",
         )
+
+    test_flow._run()
+
+def test_firestore_read_document(gcp_credentials_mock):
+    @Flow
+    def test_flow():
+        document = firestore_read_document(
+            collection="users",
+            document_id="document_id",
+            gcp_credentials=gcp_credentials_mock,
+            project="my-project",
+            location="us-central1",
+        )
+        return document
+
+    test_flow._run()
+
+def test_firestore_query_collection(gcp_credentials_mock):
+    @Flow
+    def test_flow():
+        documents = firestore_query_collection(
+            collection="users",
+            gcp_credentials=gcp_credentials_mock,
+            query_key="age",
+            query_value=30,
+            return_whole_document=False,
+            project="my-project",
+            location="us-central1",
+        )
+        return documents
 
     test_flow._run()

--- a/tests/test_firestore.py
+++ b/tests/test_firestore.py
@@ -1,124 +1,193 @@
-import os
+from unittest.mock import MagicMock, patch
+
 import pytest
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud.firestore_v1 import DocumentReference
 from prefect import Flow
-from unittest.mock import MagicMock
+
 from prefect_gcp.firestore import (
     firestore_create_collection,
     firestore_create_document,
     firestore_delete_document,
-    firestore_read_collection,
-    firestore_update_document,
-    firestore_read_document,
     firestore_query_collection,
+    firestore_read_collection,
+    firestore_read_document,
+    firestore_update_document,
 )
+
 
 @pytest.fixture
 def gcp_credentials_mock():
-    # Create a MagicMock object to mock the behavior of GcpCredentials
     mock_credentials = MagicMock()
-
-    # Mock the behavior of get_firestore_client method to return a MagicMock
     mock_firestore_client = MagicMock()
     mock_credentials.get_firestore_client.return_value = mock_firestore_client
-
     return mock_credentials
 
-def test_firestore_create_collection(gcp_credentials):
-    @Flow
-    def test_flow():
-        collection_ref = firestore_create_collection(
-            collection="users",
-            gcp_credentials=gcp_credentials,
-            project="my-project",
-            location="us-central1",
-        )
-        return collection_ref
 
-    test_flow._run()
+@pytest.fixture
+def document_reference_mock():
+    return MagicMock(spec=DocumentReference)
 
-def test_firestore_create_document(gcp_credentials):
-    @Flow
-    def test_flow():
-        document_data = {"name": "John", "age": 30}
-        document_ref = firestore_create_document(
-            collection="users",
-            document_data=document_data,
-            gcp_credentials=gcp_credentials,
-            project="my-project",
-            location="us-central1",
-        )
-        return document_ref
 
-    test_flow._run()
+def test_firestore_create_collection_success(gcp_credentials_mock):
+    with patch(
+        "prefect_gcp.firestore.firestore_create_collection"
+    ) as mock_create_collection:
+        mock_create_collection.return_value = MagicMock(spec=DocumentReference)
 
-def test_firestore_read_collection(gcp_credentials):
-    @Flow
-    def test_flow():
-        documents = firestore_read_collection(
-            collection="users",
-            gcp_credentials=gcp_credentials,
-            project="my-project",
-            location="us-central1",
-        )
-        return documents
+        @Flow
+        def test_flow():
+            collection_ref = firestore_create_collection(
+                collection="users",
+                gcp_credentials=gcp_credentials_mock,
+                project="my-project",
+                location="us-central1",
+            )
+            assert isinstance(collection_ref, DocumentReference)
 
-    test_flow._run()
+        test_flow._run()
 
-def test_firestore_update_document(gcp_credentials):
-    @Flow
-    def test_flow():
-        update_data = {"age": 35}
-        updated_doc = firestore_update_document(
-            collection="users",
-            document_id="document_id",
-            update_data=update_data,
-            gcp_credentials=gcp_credentials,
-            project="my-project",
-            location="us-central1",
-        )
-        return updated_doc
 
-    test_flow._run()
+def test_firestore_create_document_success(
+    gcp_credentials_mock, document_reference_mock
+):
+    with patch(
+        "prefect_gcp.firestore.firestore_create_document"
+    ) as mock_create_document:
+        mock_create_document.return_value = document_reference_mock
 
-def test_firestore_delete_document(gcp_credentials):
-    @Flow
-    def test_flow():
-        firestore_delete_document(
-            collection="users",
-            document_id="document_id",
-            gcp_credentials=gcp_credentials,
-            project="my-project",
-            location="us-central1",
-        )
+        @Flow
+        def test_flow():
+            document_data = {"name": "John", "age": 30}
+            document_ref = firestore_create_document(
+                collection="users",
+                document_data=document_data,
+                gcp_credentials=gcp_credentials_mock,
+                project="my-project",
+                location="us-central1",
+            )
+            assert isinstance(document_ref, DocumentReference)
 
-    test_flow._run()
+        test_flow._run()
 
-def test_firestore_read_document(gcp_credentials):
-    @Flow
-    def test_flow():
-        document = firestore_read_document(
-            collection="users",
-            document_id="document_id",
-            gcp_credentials=gcp_credentials,
-            project="my-project",
-            location="us-central1",
-        )
-        return document
 
-    test_flow._run()
+def test_firestore_read_collection_success(gcp_credentials_mock):
+    with patch(
+        "prefect_gcp.firestore.firestore_read_collection"
+    ) as mock_read_collection:
+        mock_read_collection.return_value = [{"name": "John", "age": 30}]
 
-def test_firestore_query_collection(gcp_credentials):
-    @Flow
-    def test_flow():
-        documents = firestore_query_collection(
-            collection="users",
-            gcp_credentials=gcp_credentials,
-            query_key="age",
-            query_value=30,
-            return_whole_document=False,
-            project="my-project",
-            location="us-central1",
-        )
-        return documents
+        @Flow
+        def test_flow():
+            documents = firestore_read_collection(
+                collection="users",
+                gcp_credentials=gcp_credentials_mock,
+                project="my-project",
+                location="us-central1",
+            )
+            assert isinstance(documents, list)
+            assert documents[0]["name"] == "John"
 
-    test_flow._run()
+        test_flow._run()
+
+
+def test_firestore_update_document_success(gcp_credentials_mock):
+    with patch(
+        "prefect_gcp.firestore.firestore_update_document"
+    ) as mock_update_document:
+        mock_update_document.return_value = {"name": "John", "age": 35}
+
+        @Flow
+        def test_flow():
+            update_data = {"age": 35}
+            updated_doc = firestore_update_document(
+                collection="users",
+                document_id="document_id",
+                update_data=update_data,
+                gcp_credentials=gcp_credentials_mock,
+                project="my-project",
+                location="us-central1",
+            )
+            assert updated_doc["age"] == 35
+
+        test_flow._run()
+
+
+def test_firestore_delete_document_success(gcp_credentials_mock):
+    with patch(
+        "prefect_gcp.firestore.firestore_delete_document"
+    ) as mock_delete_document:
+
+        @Flow
+        def test_flow():
+            firestore_delete_document(
+                collection="users",
+                document_id="document_id",
+                gcp_credentials=gcp_credentials_mock,
+                project="my-project",
+                location="us-central1",
+            )
+            mock_delete_document.assert_called_once()
+
+        test_flow._run()
+
+
+def test_firestore_read_document_success(gcp_credentials_mock):
+    with patch("prefect_gcp.firestore.firestore_read_document") as mock_read_document:
+        mock_read_document.return_value = {"name": "John", "age": 30}
+
+        @Flow
+        def test_flow():
+            document = firestore_read_document(
+                collection="users",
+                document_id="document_id",
+                gcp_credentials=gcp_credentials_mock,
+                project="my-project",
+                location="us-central1",
+            )
+            assert document["name"] == "John"
+
+        test_flow._run()
+
+
+def test_firestore_query_collection_success(gcp_credentials_mock):
+    with patch(
+        "prefect_gcp.firestore.firestore_query_collection"
+    ) as mock_query_collection:
+        mock_query_collection.return_value = [{"id": "123", "name": "John", "age": 30}]
+
+        @Flow
+        def test_flow():
+            documents = firestore_query_collection(
+                collection="users",
+                gcp_credentials=gcp_credentials_mock,
+                query_key="age",
+                query_value=30,
+                return_whole_document=True,
+                project="my-project",
+                location="us-central1",
+            )
+            assert len(documents) == 1
+            assert documents[0]["name"] == "John"
+
+        test_flow._run()
+
+
+def test_firestore_operation_failure(gcp_credentials_mock):
+    with patch(
+        "prefect_gcp.firestore.firestore_create_document",
+        side_effect=GoogleAPICallError("Error"),
+    ):
+
+        @Flow
+        def test_flow():
+            with pytest.raises(GoogleAPICallError):
+                firestore_create_document(
+                    collection="users",
+                    document_data={"name": "John", "age": 30},
+                    gcp_credentials=gcp_credentials_mock,
+                    project="my-project",
+                    location="us-central1",
+                )
+
+        test_flow._run()


### PR DESCRIPTION
<!-- Overview -->

Closes
#258 add gcp firestore 
### Example

     Creates a collection named "users" in Firestore using a Prefect flow.
        from prefect import Flow
        from prefect_gcp import GcpCredentials
        from prefecr_gcp.firestore import firestore_create_collection

        @Flow()
        def example_firestore_create_collection_flow():
            gcp_credentials = GcpCredentials(
                service_account_file="/path/to/service/account/keyfile.json"
            )
            collection_ref = firestore_create_collection(
                collection="users",
                gcp_credentials=gcp_credentials,
                project="my-project"
            )

        example_firestore_create_collection_flow()

### Screenshots

Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
   
<img width="1349" alt="Fire_store_mkdocs" src="https://github.com/PrefectHQ/prefect-gcp/assets/152583785/ccca72ba-efe6-4632-9f88-29ab40b8344a">

  - Service integration test results.
  
![intergration_test_result_ScnSht](https://github.com/PrefectHQ/prefect-gcp/assets/152583785/b8b01145-7e99-41ff-bf4f-4563b7c2a00b)







### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
