### PR TITLE
Remove API ref to nonexistent Google Cloud Run V2 page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,7 +84,6 @@ nav:
         - BigQuery: bigquery.md
         - Secret Manager: secret_manager.md
         - Cloud Run: cloud_run.md
-        - Cloud Run V2: cloud_run_v2.md
         - AI Platform: aiplatform.md
         - Deployment Steps: deployments/steps.md
         - Workers:


### PR DESCRIPTION
We already have one that works correctly within the [workers heading](https://prefecthq.github.io/prefect-gcp/cloud_run_worker_v2/). 

[Relevant community slack thread
](https://prefect-community.slack.com/archives/CL09KU1K7/p1711429982777029)
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-gcp/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
