### PR TITLE
The title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!NOTE]
+> Active development of this project has moved within PrefectHQ/prefect. The code can be found [here](https://github.com/PrefectHQ/prefect/tree/main/src/integrations/prefect-gcp) and documentation [here](https://docs.prefect.io/latest/integrations/prefect-gcp).
+> Please open issues and PRs against PrefectHQ/prefect instead of this repository.
+
+
 # `prefect-gcp`
 
 <p align="center">


### PR DESCRIPTION
Add redirect notice to `README.md`

With the migration of collections to prefecthq/prefect, we should make it clear that this repo's activity has moved into core.
